### PR TITLE
feat!: add multi-platform docker builds

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -33,6 +33,10 @@ jobs:
         env:
           TAG: ${{ needs.release-please.outputs.tag_name }}
 
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -43,6 +47,7 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             tastinggrounds/newtab:${{ steps.version.outputs.version }}
             tastinggrounds/newtab:latest


### PR DESCRIPTION
## Summary
- Add QEMU and Buildx setup steps to the release workflow
- Build Docker images for both `linux/amd64` and `linux/arm64` platforms
- Fixes image pull failures on Apple Silicon machines

## Test plan
- [ ] Verify the release workflow runs successfully on next release
- [ ] Confirm the published image can be pulled on both amd64 and arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)