### PR TITLE
chore: use github app token for release-please

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -17,7 +17,7 @@ jobs:
       releases_created: ${{ steps.publish.outputs.releases_created }}
       tag_name: ${{ steps.publish.outputs.tag_name }}
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: app-token
         with:
           app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}


### PR DESCRIPTION
## Summary

- Updates the release-please workflow to authenticate using a GitHub App token instead of the default `GITHUB_TOKEN`
- Adds `actions/create-github-app-token@v1` step to generate a token from `RELEASE_PLEASE_APP_ID` (repository variable) and `RELEASE_PLEASE_APP_PRIVATE_KEY` (repository secret)
- Passes the generated token to `googleapis/release-please-action@v4`

This ensures release-please PRs can trigger downstream workflows (e.g. CI checks), which the default `GITHUB_TOKEN` cannot do.

## Setup Required

1. Create a GitHub App (see PR description instructions)
2. Add `RELEASE_PLEASE_APP_ID` as a repository variable
3. Add `RELEASE_PLEASE_APP_PRIVATE_KEY` as a repository secret
4. Install the app on this repository


Made with [Cursor](https://cursor.com)