### PR TITLE
chore: add cloudflare pages deploy to release workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -59,3 +59,26 @@ jobs:
           tags: |
             tastinggrounds/newtab:${{ steps.version.outputs.version }}
             tastinggrounds/newtab:latest
+
+  deploy-cloudflare:
+    runs-on: ubuntu-latest
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist --project-name=newtab --branch=main


### PR DESCRIPTION
## Summary
- Adds a `deploy-cloudflare` job to the release-please workflow that deploys the static build to Cloudflare Pages on each release
- Runs in parallel with the existing `docker-publish` job — no added wait time
- Deploys the Vite build output (`dist/`) to the `newtab` Cloudflare Pages project using `wrangler`

## Prerequisites
Before this workflow can run successfully, the following must be configured:

**Cloudflare side:**
1. Create a Cloudflare Pages project named `newtab` (Workers & Pages > Create > Pages > Direct Upload)
2. Add custom domain `thenewtab.app` to the project
3. Create an API token using the "Edit Cloudflare Workers" template

**GitHub side:**
Add these repository secrets (Settings > Secrets and variables > Actions):
- `CLOUDFLARE_API_TOKEN`
- `CLOUDFLARE_ACCOUNT_ID`

## Test plan
- [x] Create Cloudflare Pages project and add secrets to GitHub
- [ ] Trigger a release and verify the deploy job runs successfully
- [ ] Verify thenewtab.app serves the built site

Made with [Cursor](https://cursor.com)