### PR TITLE
feat: expand command palette actions

### DIFF
--- a/src/screens/HomeScreen/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen/HomeScreen.test.tsx
@@ -56,6 +56,29 @@ describe('HomeScreen', () => {
     expect(screen.getByRole('dialog', { name: 'Commands' })).toBeInTheDocument();
   });
 
+  it('opens settings from the command palette', async () => {
+    const user = userEvent.setup();
+    const onOpenSettings = vi.fn();
+    render(<HomeScreen config={mockConfig} onSaveConfig={vi.fn()} onOpenSettings={onOpenSettings} />);
+
+    await user.keyboard('{Control>}p{/Control}');
+    await user.click(screen.getByRole('option', { name: /Open Settings/ }));
+
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('dialog', { name: 'Commands' })).not.toBeInTheDocument();
+  });
+
+  it('opens About from the command palette', async () => {
+    const user = userEvent.setup();
+    render(<HomeScreen config={mockConfig} onSaveConfig={vi.fn()} onOpenSettings={vi.fn()} />);
+
+    await user.keyboard('{Control>}p{/Control}');
+    await user.click(screen.getByRole('option', { name: /About/ }));
+
+    expect(screen.getByText(/clean, customizable new tab page/)).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Commands' })).not.toBeInTheDocument();
+  });
+
   it('restores the search hotkey after the command palette closes', async () => {
     const user = userEvent.setup();
     render(<HomeScreen config={mockConfig} onSaveConfig={vi.fn()} onOpenSettings={vi.fn()} />);

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -108,6 +108,8 @@ export function HomeScreen({ config, onSaveConfig, onOpenSettings }: HomeScreenP
           config={config}
           onSave={onSaveConfig}
           onClose={() => setShowCommands(false)}
+          onOpenSettings={onOpenSettings}
+          onOpenAbout={() => setShowAbout(true)}
         />
       )}
     </>

--- a/src/screens/HomeScreen/components/CommandPalette.test.tsx
+++ b/src/screens/HomeScreen/components/CommandPalette.test.tsx
@@ -8,9 +8,19 @@ function renderPalette(
   config: AppConfig = mockConfig,
   onSave = vi.fn(),
   onClose = vi.fn(),
+  onOpenSettings = vi.fn(),
+  onOpenAbout = vi.fn(),
 ) {
-  render(<CommandPalette config={config} onSave={onSave} onClose={onClose} />);
-  return { onSave, onClose };
+  render(
+    <CommandPalette
+      config={config}
+      onSave={onSave}
+      onClose={onClose}
+      onOpenSettings={onOpenSettings}
+      onOpenAbout={onOpenAbout}
+    />,
+  );
+  return { onSave, onClose, onOpenSettings, onOpenAbout };
 }
 
 async function openAddLinkForm(user: ReturnType<typeof userEvent.setup>) {
@@ -37,9 +47,29 @@ describe('CommandPalette', () => {
     const user = userEvent.setup();
     renderPalette();
 
-    await user.keyboard('{ArrowDown}{Enter}');
+    await user.keyboard('{Enter}');
     expect(screen.getByRole('heading', { name: 'Add Link' })).toBeInTheDocument();
     expect(screen.getByLabelText('Link URL')).toHaveFocus();
+  });
+
+  it('opens settings and closes the command palette', async () => {
+    const user = userEvent.setup();
+    const { onClose, onOpenSettings } = renderPalette();
+
+    await user.click(screen.getByRole('option', { name: /Open Settings/ }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+
+  it('opens About and closes the command palette', async () => {
+    const user = userEvent.setup();
+    const { onClose, onOpenAbout } = renderPalette();
+
+    await user.click(screen.getByRole('option', { name: /About/ }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onOpenAbout).toHaveBeenCalledOnce();
   });
 
   it('closes on Escape and backdrop click', async () => {
@@ -228,10 +258,10 @@ describe('CommandPalette', () => {
     renderPalette();
 
     const close = screen.getByRole('button', { name: 'Close commands' });
-    const option = screen.getByRole('option', { name: /Add Link/ });
+    const lastOption = screen.getByRole('option', { name: /About/ });
     close.focus();
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Tab', shiftKey: true });
-    expect(option).toHaveFocus();
+    expect(lastOption).toHaveFocus();
 
     fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Tab' });
     expect(close).toHaveFocus();

--- a/src/screens/HomeScreen/components/CommandPalette.tsx
+++ b/src/screens/HomeScreen/components/CommandPalette.tsx
@@ -3,8 +3,8 @@ import { useHotkey } from '@tanstack/react-hotkeys';
 import type { AppConfig, ModuleConfig } from '../../../types/config.ts';
 import { ensureProtocol, MAX_LINK_LABEL, MAX_SECTION_NAME } from '../../../utils/linkConfig.ts';
 
-type CommandId = 'add-link';
-type PaletteView = 'commands' | CommandId;
+type CommandId = 'add-link' | 'open-settings' | 'about';
+type PaletteView = 'commands' | 'add-link';
 
 interface CommandDefinition {
   id: CommandId;
@@ -20,15 +20,29 @@ const COMMANDS = [
     description: 'Create a link in a category',
     keywords: ['bookmark', 'url', 'folder', 'category'],
   },
+  {
+    id: 'open-settings',
+    label: 'Open Settings',
+    description: 'Customize your new tab page',
+    keywords: ['config', 'preferences', 'edit'],
+  },
+  {
+    id: 'about',
+    label: 'About',
+    description: 'View app information and links',
+    keywords: ['info', 'version', 'github'],
+  },
 ] satisfies readonly CommandDefinition[];
 
 interface CommandPaletteProps {
   config: AppConfig;
   onSave: (config: AppConfig) => void;
   onClose: () => void;
+  onOpenSettings: () => void;
+  onOpenAbout: () => void;
 }
 
-interface AddLinkFormProps extends CommandPaletteProps {
+interface AddLinkFormProps extends Pick<CommandPaletteProps, 'config' | 'onSave' | 'onClose'> {
   onBack: () => void;
 }
 
@@ -294,7 +308,41 @@ function AddLinkForm({ config, onSave, onClose, onBack }: AddLinkFormProps) {
   );
 }
 
-export function CommandPalette({ config, onSave, onClose }: CommandPaletteProps) {
+function CommandIcon({ id }: { id: CommandId }) {
+  if (id === 'open-settings') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="3" />
+        <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+      </svg>
+    );
+  }
+
+  if (id === 'about') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="10" />
+        <line x1="12" y1="16" x2="12" y2="12" />
+        <line x1="12" y1="8" x2="12.01" y2="8" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </svg>
+  );
+}
+
+export function CommandPalette({
+  config,
+  onSave,
+  onClose,
+  onOpenSettings,
+  onOpenAbout,
+}: CommandPaletteProps) {
   const [view, setView] = useState<PaletteView>('commands');
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -327,7 +375,17 @@ export function CommandPalette({ config, onSave, onClose }: CommandPaletteProps)
   }, [view]);
 
   const activateCommand = (command: CommandDefinition) => {
-    setView(command.id);
+    if (command.id === 'add-link') {
+      setView(command.id);
+      return;
+    }
+
+    onClose();
+    if (command.id === 'open-settings') {
+      onOpenSettings();
+    } else {
+      onOpenAbout();
+    }
   };
 
   const handleCommandKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -434,10 +492,7 @@ export function CommandPalette({ config, onSave, onClose }: CommandPaletteProps)
                   onClick={() => activateCommand(command)}
                 >
                   <span className="command-list-icon" aria-hidden="true">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M12 5v14" />
-                      <path d="M5 12h14" />
-                    </svg>
+                    <CommandIcon id={command.id} />
                   </span>
                   <span className="command-list-copy">
                     <span className="command-list-label">{command.label}</span>


### PR DESCRIPTION
Adds searchable Open Settings and About actions to the command palette with distinct icons and keyboard support. Both actions close the palette before opening their destination. Adds command-palette unit tests and home-screen integration coverage.

Testing: `npm run lint && npm run test && npm run build`