### PR TITLE
feat: add reliable foreground contrast controls for images and gradients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ src/
 ├── hooks/
 │   └── useConfig.ts       — fetches /config.json, persists to localStorage
 ├── utils/
-│   └── linkConfig.ts     — shared link constraints and URL normalization
+│   ├── linkConfig.ts     — shared link constraints and URL normalization
+│   └── foreground.ts     — foreground (text color) resolution from background config
 ├── index.css              — base reset + CSS custom properties
 ├── main.tsx
 └── types/
@@ -57,7 +58,7 @@ Shared components used across screens stay in `src/components/`.
 
 ## Style
 
-- Adaptive text color via CSS custom properties — `--fg` (RGB triplet) is set dynamically based on background color luminance (`0, 0, 0` on light backgrounds, `255, 255, 255` on dark). All text and translucent surfaces must use `rgb(var(--fg))` / `rgba(var(--fg), <alpha>)` instead of hardcoded `#fff` or `rgba(255,255,255,...)`.
+- Adaptive text color via CSS custom properties — `--fg` (RGB triplet) is set dynamically by `resolveForeground` in `src/utils/foreground.ts` (`0, 0, 0` on light backgrounds, `255, 255, 255` on dark), or forced by the `background.foreground` setting (`auto` | `light` | `dark`). All text and translucent surfaces must use `rgb(var(--fg))` / `rgba(var(--fg), <alpha>)` instead of hardcoded `#fff` or `rgba(255,255,255,...)`.
 - `--dropdown-bg` (RGB triplet) is used for dropdown surfaces, also flips with background luminance.
 - Translucent cards use `rgba(var(--fg), 0.05)`
 - System font stack

--- a/public/config.json
+++ b/public/config.json
@@ -4,6 +4,7 @@
     "imageUrl": "",
     "opacity": 0.4,
     "color": "#1a1a2e",
+    "foreground": "auto",
     "gradient": {
       "enabled": true,
       "color2": "#2b82fb",

--- a/src/App.css
+++ b/src/App.css
@@ -575,6 +575,12 @@
   transition: background 150ms, color 150ms, border-color 150ms;
 }
 
+.config-editor-foreground-btn {
+  width: auto;
+  padding: 0 14px;
+  font-size: 0.85rem;
+}
+
 .config-editor-direction-btn:hover {
   background: rgba(var(--fg), 0.12);
   color: rgba(var(--fg), 0.7);

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import App from './App.tsx';
+import { mockConfig } from './test/fixtures.ts';
+import type { AppConfig, BackgroundConfig } from './types/config.ts';
+
+const STORAGE_KEY = 'newtab-config';
+
+function seedConfig(background: BackgroundConfig) {
+  const config: AppConfig = { ...mockConfig, background };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+}
+
+const fg = () => document.documentElement.style.getPropertyValue('--fg');
+const dropdownBg = () => document.documentElement.style.getPropertyValue('--dropdown-bg');
+
+describe('App foreground resolution', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.style.removeProperty('--fg');
+    document.documentElement.style.removeProperty('--dropdown-bg');
+  });
+
+  it('uses a light foreground on a dark background', () => {
+    seedConfig({ color: '#1a1a2e' });
+    render(<App />);
+    expect(fg()).toBe('255, 255, 255');
+    expect(dropdownBg()).toBe('30, 30, 30');
+  });
+
+  it('uses a dark foreground on a light background', () => {
+    seedConfig({ color: '#f5f5f5' });
+    render(<App />);
+    expect(fg()).toBe('0, 0, 0');
+    expect(dropdownBg()).toBe('240, 240, 240');
+  });
+
+  it('honors a saved explicit override that contradicts the background', () => {
+    seedConfig({ color: '#f5f5f5', foreground: 'light' });
+    render(<App />);
+    expect(fg()).toBe('255, 255, 255');
+  });
+
+  it('applies the override live in preview and keeps it after saving', async () => {
+    const user = userEvent.setup();
+    seedConfig({ color: '#1a1a2e' });
+    render(<App />);
+    expect(fg()).toBe('255, 255, 255');
+
+    await user.click(screen.getByLabelText('Settings'));
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+
+    // Preview resolves through the same logic as the home screen
+    expect(fg()).toBe('0, 0, 0');
+    expect(dropdownBg()).toBe('240, 240, 240');
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(fg()).toBe('0, 0, 0');
+
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY)!) as AppConfig;
+    expect(saved.background?.foreground).toBe('dark');
+  });
+
+  it('reverts the preview override when settings are cancelled', async () => {
+    const user = userEvent.setup();
+    seedConfig({ color: '#1a1a2e' });
+    render(<App />);
+
+    await user.click(screen.getByLabelText('Settings'));
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+    expect(fg()).toBe('0, 0, 0');
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(fg()).toBe('255, 255, 255');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,25 +4,8 @@ import type { BackgroundConfig } from './types/config.ts';
 import { BackgroundLayer } from './components/BackgroundLayer.tsx';
 import { HomeScreen } from './screens/HomeScreen/index.ts';
 import { ConfigEditor } from './screens/ConfigEditorScreen/index.ts';
+import { resolveForeground, foregroundCssVars } from './utils/foreground.ts';
 import './App.css';
-
-function hexLuminance(hex: string): number {
-  const r = parseInt(hex.slice(1, 3), 16) / 255;
-  const g = parseInt(hex.slice(3, 5), 16) / 255;
-  const b = parseInt(hex.slice(5, 7), 16) / 255;
-  const toLinear = (c: number) =>
-    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
-  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
-}
-
-function isLightBackground(bg: BackgroundConfig | undefined): boolean {
-  const color = bg?.color ?? '#1a1a2e';
-  if (bg?.gradient?.enabled && bg.gradient.color2) {
-    const avg = (hexLuminance(color) + hexLuminance(bg.gradient.color2)) / 2;
-    return avg > 0.179;
-  }
-  return hexLuminance(color) > 0.179;
-}
 
 function App() {
   const { config, loading, error, setConfig } = useConfig();
@@ -32,14 +15,16 @@ function App() {
   const effectiveBackground: BackgroundConfig | undefined =
     (showConfig && previewBackground) ? previewBackground : config?.background;
 
-  const light = useMemo(() => isLightBackground(effectiveBackground), [effectiveBackground]);
+  const foreground = useMemo(
+    () => resolveForeground(effectiveBackground),
+    [effectiveBackground],
+  );
 
   useEffect(() => {
-    const fg = light ? '0, 0, 0' : '255, 255, 255';
-    const dropdownBg = light ? '240, 240, 240' : '30, 30, 30';
+    const { fg, dropdownBg } = foregroundCssVars(foreground);
     document.documentElement.style.setProperty('--fg', fg);
     document.documentElement.style.setProperty('--dropdown-bg', dropdownBg);
-  }, [light]);
+  }, [foreground]);
 
   if (loading) {
     return <div className="loading">Loading...</div>;

--- a/src/screens/ConfigEditorScreen/components/GeneralTab.test.tsx
+++ b/src/screens/ConfigEditorScreen/components/GeneralTab.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GeneralTab } from './GeneralTab.tsx';
 import { mockConfig, mockBackgroundWithImage } from '../../../test/fixtures.ts';
-import type { AppConfig } from '../../../types/config.ts';
+import type { AppConfig, BackgroundConfig } from '../../../types/config.ts';
 
 describe('GeneralTab', () => {
   const defaultProps = {
@@ -113,6 +113,56 @@ describe('GeneralTab', () => {
     };
     render(<GeneralTab {...defaultProps} config={configWithImage} />);
     expect(screen.getByText(/Overlay Opacity/)).toBeInTheDocument();
+  });
+
+  it('defaults the foreground control to Auto', () => {
+    render(<GeneralTab {...defaultProps} />);
+    expect(screen.getByText('Foreground')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Auto' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Dark' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('reflects the saved foreground setting', () => {
+    const configWithForeground: AppConfig = {
+      ...mockConfig,
+      background: { ...mockConfig.background, foreground: 'dark' },
+    };
+    render(<GeneralTab {...defaultProps} config={configWithForeground} />);
+    expect(screen.getByRole('button', { name: 'Dark' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('previews the foreground override immediately', async () => {
+    const user = userEvent.setup();
+    const onPreview = vi.fn();
+    render(<GeneralTab {...defaultProps} onPreview={onPreview} />);
+
+    await user.click(screen.getByRole('button', { name: 'Light' }));
+
+    const previewed = onPreview.mock.calls.at(-1)?.[0] as BackgroundConfig;
+    expect(previewed.foreground).toBe('light');
+  });
+
+  it('saves the selected foreground setting', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<GeneralTab {...defaultProps} onSave={onSave} />);
+
+    await user.click(screen.getByRole('button', { name: 'Dark' }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const savedConfig = onSave.mock.calls[0][0] as AppConfig;
+    expect(savedConfig.background?.foreground).toBe('dark');
+  });
+
+  it('keeps the foreground setting in the shared draft', async () => {
+    const user = userEvent.setup();
+    const onConfigChange = vi.fn();
+    render(<GeneralTab {...defaultProps} onConfigChange={onConfigChange} />);
+
+    await user.click(screen.getByRole('button', { name: 'Light' }));
+
+    const draft = onConfigChange.mock.calls.at(-1)?.[0] as AppConfig;
+    expect(draft.background?.foreground).toBe('light');
   });
 
   it('calls onClose when Cancel is clicked', async () => {

--- a/src/screens/ConfigEditorScreen/components/GeneralTab.tsx
+++ b/src/screens/ConfigEditorScreen/components/GeneralTab.tsx
@@ -1,11 +1,17 @@
 import { useState, useEffect } from 'react';
-import type { AppConfig, BackgroundConfig, GradientDirection } from '../../../types/config.ts';
+import type { AppConfig, BackgroundConfig, ForegroundSetting, GradientDirection } from '../../../types/config.ts';
 
 const DIRECTION_ARROWS: { value: GradientDirection; arrow: string }[] = [
   { value: 'up', arrow: '↑' },
   { value: 'down', arrow: '↓' },
   { value: 'left', arrow: '←' },
   { value: 'right', arrow: '→' },
+];
+
+const FOREGROUND_OPTIONS: { value: ForegroundSetting; label: string }[] = [
+  { value: 'auto', label: 'Auto' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
 ];
 
 interface GeneralTabProps {
@@ -24,25 +30,29 @@ export function GeneralTab({ config, onSave, onClose, onPreview, onConfigChange 
   const [gradientEnabled, setGradientEnabled] = useState(config.background?.gradient?.enabled ?? false);
   const [gradientColor2, setGradientColor2] = useState(config.background?.gradient?.color2 ?? '#000000');
   const [gradientDirection, setGradientDirection] = useState<GradientDirection>(config.background?.gradient?.direction ?? 'down');
+  const [foreground, setForeground] = useState<ForegroundSetting>(config.background?.foreground ?? 'auto');
   const [placeholder, setPlaceholder] = useState(config.search?.placeholder ?? '');
 
   const hasImage = appliedImageUrl.trim() !== '';
+
+  const currentBackground = (): BackgroundConfig => ({
+    ...config.background,
+    imageUrl: appliedImageUrl || undefined,
+    opacity,
+    color,
+    foreground,
+    gradient: {
+      enabled: gradientEnabled,
+      color2: gradientColor2,
+      direction: gradientDirection,
+    },
+  });
 
   // Push general-tab changes to the shared draft so they persist across tab switches
   useEffect(() => {
     const updated: AppConfig = {
       ...config,
-      background: {
-        ...config.background,
-        imageUrl: appliedImageUrl || undefined,
-        opacity,
-        color,
-        gradient: {
-          enabled: gradientEnabled,
-          color2: gradientColor2,
-          direction: gradientDirection,
-        },
-      },
+      background: currentBackground(),
       search: {
         ...config.search,
         enabled: config.search?.enabled ?? false,
@@ -50,7 +60,7 @@ export function GeneralTab({ config, onSave, onClose, onPreview, onConfigChange 
       },
     };
     onConfigChange(updated);
-  }, [appliedImageUrl, opacity, color, gradientEnabled, gradientColor2, gradientDirection, placeholder]);// eslint-disable-line react-hooks/exhaustive-deps
+  }, [appliedImageUrl, opacity, color, foreground, gradientEnabled, gradientColor2, gradientDirection, placeholder]);// eslint-disable-line react-hooks/exhaustive-deps
 
   const buildGradient = (updates: { enabled?: boolean; color2?: string; direction?: GradientDirection } = {}) => ({
     enabled: updates.enabled ?? gradientEnabled,
@@ -62,12 +72,14 @@ export function GeneralTab({ config, onSave, onClose, onPreview, onConfigChange 
     imageUrl?: string;
     opacity?: number;
     color?: string;
+    foreground?: ForegroundSetting;
     gradient?: { enabled?: boolean; color2?: string; direction?: GradientDirection };
   }) => {
     const next: BackgroundConfig = {
       imageUrl: (updates.imageUrl ?? appliedImageUrl) || undefined,
       opacity: updates.opacity ?? opacity,
       color: updates.color ?? color,
+      foreground: updates.foreground ?? foreground,
       gradient: buildGradient(updates.gradient),
     };
     onPreview(next);
@@ -87,17 +99,7 @@ export function GeneralTab({ config, onSave, onClose, onPreview, onConfigChange 
   const handleSave = () => {
     onSave({
       ...config,
-      background: {
-        ...config.background,
-        imageUrl: appliedImageUrl || undefined,
-        opacity,
-        color,
-        gradient: {
-          enabled: gradientEnabled,
-          color2: gradientColor2,
-          direction: gradientDirection,
-        },
-      },
+      background: currentBackground(),
       search: {
         ...config.search,
         enabled: config.search?.enabled ?? false,
@@ -212,6 +214,26 @@ export function GeneralTab({ config, onSave, onClose, onPreview, onConfigChange 
             </div>
           </>
         )}
+
+        <div className="config-editor-field">
+          <span className="config-editor-label">Foreground</span>
+          <div className="config-editor-direction-row" role="group" aria-label="Foreground">
+            {FOREGROUND_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className={`config-editor-direction-btn config-editor-foreground-btn${foreground === opt.value ? ' active' : ''}`}
+                aria-pressed={foreground === opt.value}
+                onClick={() => {
+                  setForeground(opt.value);
+                  updatePreview({ foreground: opt.value });
+                }}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
 
       <div className="config-editor-section config-editor-section-gap">

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -21,11 +21,15 @@ export interface GradientConfig {
   direction: GradientDirection;
 }
 
+export type ForegroundSetting = 'auto' | 'light' | 'dark';
+
 export interface BackgroundConfig {
   imageUrl?: string;
   opacity?: number;
   color?: string;
   gradient?: GradientConfig;
+  /** Foreground content color: `auto` derives it from the background. */
+  foreground?: ForegroundSetting;
 }
 
 export interface SearchConfig {

--- a/src/utils/foreground.test.ts
+++ b/src/utils/foreground.test.ts
@@ -1,0 +1,186 @@
+import {
+  hexLuminance,
+  backgroundLuminanceRange,
+  resolveForeground,
+  foregroundCssVars,
+} from './foreground.ts';
+import type { BackgroundConfig } from '../types/config.ts';
+
+describe('hexLuminance', () => {
+  it('computes luminance for the extremes', () => {
+    expect(hexLuminance('#000000')).toBe(0);
+    expect(hexLuminance('#ffffff')).toBe(1);
+  });
+
+  it('supports shorthand hex', () => {
+    expect(hexLuminance('#fff')).toBe(hexLuminance('#ffffff'));
+  });
+
+  it('returns null for unparseable values', () => {
+    expect(hexLuminance('nope')).toBeNull();
+    expect(hexLuminance('')).toBeNull();
+    expect(hexLuminance('rgb(0,0,0)')).toBeNull();
+  });
+});
+
+describe('resolveForeground — explicit override', () => {
+  it('forces light foreground regardless of background', () => {
+    expect(resolveForeground({ color: '#ffffff', foreground: 'light' })).toBe('light');
+  });
+
+  it('forces dark foreground regardless of background', () => {
+    expect(resolveForeground({ color: '#000000', foreground: 'dark' })).toBe('dark');
+  });
+
+  it('overrides image backgrounds where pixel analysis is unavailable', () => {
+    const bg: BackgroundConfig = {
+      imageUrl: 'https://example.com/bright.jpg',
+      color: '#000000',
+      opacity: 0.1,
+      foreground: 'dark',
+    };
+    expect(resolveForeground(bg)).toBe('dark');
+  });
+
+  it('treats auto the same as an unset value', () => {
+    expect(resolveForeground({ color: '#ffffff', foreground: 'auto' })).toBe('dark');
+    expect(resolveForeground({ color: '#ffffff' })).toBe('dark');
+  });
+});
+
+describe('resolveForeground — solid backgrounds', () => {
+  it('picks light foreground on dark colors', () => {
+    expect(resolveForeground({ color: '#1a1a2e' })).toBe('light');
+    expect(resolveForeground({ color: '#000000' })).toBe('light');
+  });
+
+  it('picks dark foreground on light colors', () => {
+    expect(resolveForeground({ color: '#ffffff' })).toBe('dark');
+    expect(resolveForeground({ color: '#f0e6d2' })).toBe('dark');
+  });
+
+  it('falls back to the default dark background when unset or invalid', () => {
+    expect(resolveForeground(undefined)).toBe('light');
+    expect(resolveForeground({ color: 'not-a-color' })).toBe('light');
+  });
+
+  it('ignores gradient colors when the gradient is disabled', () => {
+    const bg: BackgroundConfig = {
+      color: '#000000',
+      gradient: { enabled: false, color2: '#ffffff', direction: 'down' },
+    };
+    expect(backgroundLuminanceRange(bg)).toEqual({ min: 0, max: 0 });
+  });
+});
+
+describe('resolveForeground — gradients', () => {
+  it('spans both stops instead of averaging them', () => {
+    const bg: BackgroundConfig = {
+      color: '#000000',
+      gradient: { enabled: true, color2: '#dddddd', direction: 'down' },
+    };
+    const range = backgroundLuminanceRange(bg);
+    expect(range.min).toBe(0);
+    expect(range.max).toBeCloseTo(hexLuminance('#dddddd')!, 10);
+    // Average luminance would exceed the light threshold and pick dark text,
+    // which is unreadable over the black stop.
+    expect(resolveForeground(bg)).toBe('light');
+  });
+
+  it('picks dark foreground only when both stops are light', () => {
+    const bg: BackgroundConfig = {
+      color: '#ffffff',
+      gradient: { enabled: true, color2: '#e8e8e8', direction: 'right' },
+    };
+    expect(resolveForeground(bg)).toBe('dark');
+  });
+
+  it('is independent of stop order', () => {
+    const a: BackgroundConfig = {
+      color: '#000000',
+      gradient: { enabled: true, color2: '#dddddd', direction: 'down' },
+    };
+    const b: BackgroundConfig = {
+      color: '#dddddd',
+      gradient: { enabled: true, color2: '#000000', direction: 'down' },
+    };
+    expect(resolveForeground(a)).toBe(resolveForeground(b));
+  });
+
+  it('ignores an unparseable second stop', () => {
+    const bg: BackgroundConfig = {
+      color: '#ffffff',
+      gradient: { enabled: true, color2: 'oops', direction: 'down' },
+    };
+    expect(backgroundLuminanceRange(bg)).toEqual({ min: 1, max: 1 });
+  });
+});
+
+describe('resolveForeground — images and overlay opacity', () => {
+  it('widens the luminance range as overlay opacity drops', () => {
+    const overlay = { imageUrl: 'https://example.com/bg.jpg', color: '#000000' };
+    const opaque = backgroundLuminanceRange({ ...overlay, opacity: 1 });
+    const sheer = backgroundLuminanceRange({ ...overlay, opacity: 0.2 });
+
+    expect(opaque).toEqual({ min: 0, max: 0 });
+    expect(sheer.max).toBeCloseTo(0.8, 10);
+  });
+
+  it('trusts the overlay color when it is nearly opaque', () => {
+    const bg: BackgroundConfig = {
+      imageUrl: 'https://example.com/bg.jpg',
+      color: '#ffffff',
+      opacity: 0.95,
+    };
+    expect(resolveForeground(bg)).toBe('dark');
+  });
+
+  it('does not treat a mid-tone overlay as if the image were not there', () => {
+    const solid: BackgroundConfig = { color: '#666666' };
+    const overImage: BackgroundConfig = {
+      imageUrl: 'https://example.com/bg.jpg',
+      color: '#666666',
+      opacity: 0.5,
+    };
+    expect(resolveForeground(solid)).toBe('light');
+    expect(resolveForeground(overImage)).toBe('dark');
+  });
+
+  it('uses the default overlay opacity when unset', () => {
+    const bg: BackgroundConfig = { imageUrl: 'https://example.com/bg.jpg', color: '#000000' };
+    expect(backgroundLuminanceRange(bg)).toEqual(
+      backgroundLuminanceRange({ ...bg, opacity: 0.4 }),
+    );
+  });
+
+  it('clamps out-of-range opacity values', () => {
+    const bg: BackgroundConfig = { imageUrl: 'https://example.com/bg.jpg', color: '#000000' };
+    expect(backgroundLuminanceRange({ ...bg, opacity: 5 })).toEqual({ min: 0, max: 0 });
+    expect(backgroundLuminanceRange({ ...bg, opacity: -2 })).toEqual({ min: 0, max: 1 });
+  });
+
+  it('ignores an empty image url', () => {
+    const bg: BackgroundConfig = { imageUrl: '   ', color: '#ffffff', opacity: 0.1 };
+    expect(backgroundLuminanceRange(bg)).toEqual({ min: 1, max: 1 });
+  });
+
+  it('combines a gradient overlay with the image range', () => {
+    const bg: BackgroundConfig = {
+      imageUrl: 'https://example.com/bg.jpg',
+      color: '#000000',
+      opacity: 0.5,
+      gradient: { enabled: true, color2: '#ffffff', direction: 'down' },
+    };
+    expect(backgroundLuminanceRange(bg)).toEqual({ min: 0, max: 1 });
+  });
+});
+
+describe('foregroundCssVars', () => {
+  it('maps light foreground to white text and a dark dropdown surface', () => {
+    expect(foregroundCssVars('light')).toEqual({ fg: '255, 255, 255', dropdownBg: '30, 30, 30' });
+  });
+
+  it('maps dark foreground to black text and a light dropdown surface', () => {
+    expect(foregroundCssVars('dark')).toEqual({ fg: '0, 0, 0', dropdownBg: '240, 240, 240' });
+  });
+});

--- a/src/utils/foreground.ts
+++ b/src/utils/foreground.ts
@@ -1,0 +1,102 @@
+import type { BackgroundConfig } from '../types/config.ts';
+
+/** The resolved foreground content color: `light` = white text, `dark` = black text. */
+export type ResolvedForeground = 'light' | 'dark';
+
+export const DEFAULT_BACKGROUND_COLOR = '#1a1a2e';
+export const DEFAULT_OVERLAY_OPACITY = 0.4;
+
+const HEX_SHORT = /^#([0-9a-f])([0-9a-f])([0-9a-f])$/i;
+const HEX_LONG = /^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i;
+
+/** WCAG relative luminance for a hex color, or `null` if the value is not parseable. */
+export function hexLuminance(hex: string): number | null {
+  const value = hex.trim();
+  const short = HEX_SHORT.exec(value);
+  const long = HEX_LONG.exec(value);
+  if (!short && !long) return null;
+
+  const parts = short
+    ? [short[1] + short[1], short[2] + short[2], short[3] + short[3]]
+    : [long![1], long![2], long![3]];
+
+  const [r, g, b] = parts.map((part) => parseInt(part, 16) / 255);
+  const toLinear = (c: number) =>
+    c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+
+/** WCAG contrast ratio between white and a background of the given luminance. */
+function contrastWithWhite(luminance: number): number {
+  return 1.05 / (luminance + 0.05);
+}
+
+/** WCAG contrast ratio between black and a background of the given luminance. */
+function contrastWithBlack(luminance: number): number {
+  return (luminance + 0.05) / 0.05;
+}
+
+/**
+ * The range of luminance the foreground has to stay readable against.
+ *
+ * Gradients span both stops rather than collapsing to an average, and images
+ * (whose pixels we cannot reliably sample — remote images are usually blocked
+ * by CORS) are treated as covering the full luminance range behind the overlay,
+ * so the range widens as overlay opacity drops.
+ */
+export function backgroundLuminanceRange(
+  bg: BackgroundConfig | undefined,
+): { min: number; max: number } {
+  const base = hexLuminance(bg?.color ?? DEFAULT_BACKGROUND_COLOR)
+    ?? hexLuminance(DEFAULT_BACKGROUND_COLOR)!;
+
+  const stops = [base];
+  if (bg?.gradient?.enabled && bg.gradient.color2) {
+    const second = hexLuminance(bg.gradient.color2);
+    if (second !== null) stops.push(second);
+  }
+
+  let min = Math.min(...stops);
+  let max = Math.max(...stops);
+
+  if (bg?.imageUrl && bg.imageUrl.trim() !== '') {
+    const rawOpacity = bg.opacity ?? DEFAULT_OVERLAY_OPACITY;
+    const opacity = Number.isFinite(rawOpacity)
+      ? Math.min(1, Math.max(0, rawOpacity))
+      : DEFAULT_OVERLAY_OPACITY;
+    // Composite luminance ≈ opacity * overlay + (1 - opacity) * unknown image,
+    // with the unknown image spanning [0, 1].
+    min = opacity * min;
+    max = opacity * max + (1 - opacity);
+  }
+
+  return { min, max };
+}
+
+/**
+ * Resolve the foreground content color for a background.
+ *
+ * An explicit `light`/`dark` setting always wins. In `auto` mode we pick the
+ * color with the better worst-case contrast across the background's luminance
+ * range, which reduces to the usual luminance threshold for solid colors.
+ */
+export function resolveForeground(
+  bg: BackgroundConfig | undefined,
+): ResolvedForeground {
+  if (bg?.foreground === 'light' || bg?.foreground === 'dark') {
+    return bg.foreground;
+  }
+
+  const { min, max } = backgroundLuminanceRange(bg);
+  return contrastWithWhite(max) >= contrastWithBlack(min) ? 'light' : 'dark';
+}
+
+/** CSS custom property values that follow the resolved foreground. */
+export function foregroundCssVars(foreground: ResolvedForeground): {
+  fg: string;
+  dropdownBg: string;
+} {
+  return foreground === 'light'
+    ? { fg: '255, 255, 255', dropdownBg: '30, 30, 30' }
+    : { fg: '0, 0, 0', dropdownBg: '240, 240, 240' };
+}


### PR DESCRIPTION
Closes #54

## What

Adds an explicit `background.foreground` setting (`auto` | `light` | `dark`) and replaces the average-luminance foreground heuristic with a worst-case contrast model.

- `src/utils/foreground.ts` — new `resolveForeground`, `backgroundLuminanceRange`, `hexLuminance`, `foregroundCssVars`.
- Gradients span **both** stops rather than collapsing to an average, so a black→light-grey gradient no longer picks black text that is unreadable over the dark stop.
- Background images are treated as unknown luminance behind the overlay: the range is `[opacity * overlay, opacity * overlay + (1 - opacity)]`, so it widens as overlay opacity drops instead of trusting the overlay color alone.
- Auto mode picks whichever of white/black has the better worst-case WCAG contrast across that range. For a solid color this reduces exactly to the previous `0.179` threshold, so solid backgrounds behave as before.
- Explicit `light`/`dark` always wins — the escape hatch for remote images where pixel sampling is blocked by CORS.
- Settings → General gains a Foreground segmented control (Auto/Light/Dark) with live preview; `--fg` and `--dropdown-bg` both follow the resolved value, so dropdown surfaces and translucent cards come along.
- Preview and the saved home screen both go through `resolveForeground`, so there is one resolution path.

## Tests

- `src/utils/foreground.test.ts` — solid, gradient, image/opacity, overrides, invalid hex, opacity clamping (24 tests).
- `src/App.test.tsx` — new: end-to-end `--fg`/`--dropdown-bg` for saved config, live preview, save, and cancel-reverts.
- `GeneralTab.test.tsx` — control default, saved state, preview, save, draft persistence.

`npm run lint && npm run test && npm run build` all pass (143 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)