### PR TITLE
feat: add account auth commands

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,6 +110,7 @@ function App() {
         account={account}
         syncStatus={syncStatus}
         onOpenAccount={account.status === 'disabled' ? undefined : () => openSettings('account')}
+        onSignOut={account.status === 'signed-in' ? signOut : undefined}
       />
       {initialSyncConflict && (
         <SyncConflictModal

--- a/src/screens/HomeScreen/HomeScreen.test.tsx
+++ b/src/screens/HomeScreen/HomeScreen.test.tsx
@@ -86,6 +86,47 @@ describe('HomeScreen', () => {
     expect(screen.queryByRole('dialog', { name: 'Commands' })).not.toBeInTheDocument();
   });
 
+  it('opens the account screen from the command palette', async () => {
+    const user = userEvent.setup();
+    const onOpenAccount = vi.fn();
+    render(
+      <HomeScreen
+        config={mockConfig}
+        onSaveConfig={vi.fn()}
+        onOpenSettings={vi.fn()}
+        account={{ status: 'signed-out' }}
+        onOpenAccount={onOpenAccount}
+      />,
+    );
+
+    await user.keyboard('{Control>}p{/Control}');
+    await user.click(screen.getByRole('option', { name: /^Account/ }));
+
+    expect(onOpenAccount).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('dialog', { name: 'Commands' })).not.toBeInTheDocument();
+  });
+
+  it('signs out from the command palette when signed in', async () => {
+    const user = userEvent.setup();
+    const onSignOut = vi.fn().mockResolvedValue(undefined);
+    render(
+      <HomeScreen
+        config={mockConfig}
+        onSaveConfig={vi.fn()}
+        onOpenSettings={vi.fn()}
+        account={{ status: 'signed-in', userId: 'user-1', email: 'person@example.com' }}
+        onOpenAccount={vi.fn()}
+        onSignOut={onSignOut}
+      />,
+    );
+
+    await user.keyboard('{Control>}p{/Control}');
+    await user.click(screen.getByRole('option', { name: /^Sign Out/ }));
+
+    expect(onSignOut).toHaveBeenCalledOnce();
+    expect(screen.queryByRole('dialog', { name: 'Commands' })).not.toBeInTheDocument();
+  });
+
   it('opens About from the command palette', async () => {
     const user = userEvent.setup();
     render(<HomeScreen config={mockConfig} onSaveConfig={vi.fn()} onOpenSettings={vi.fn()} />);

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -15,6 +15,7 @@ interface HomeScreenProps {
   account?: AccountState;
   syncStatus?: SyncStatus;
   onOpenAccount?: () => void;
+  onSignOut?: () => void | Promise<void>;
 }
 
 export function HomeScreen({
@@ -24,6 +25,7 @@ export function HomeScreen({
   account,
   syncStatus = 'local',
   onOpenAccount,
+  onSignOut,
 }: HomeScreenProps) {
   const [navigating, setNavigating] = useState<{ url: string; label: string } | null>(null);
   const [showAbout, setShowAbout] = useState(false);
@@ -139,6 +141,9 @@ export function HomeScreen({
           onClose={() => setShowCommands(false)}
           onOpenSettings={onOpenSettings}
           onOpenAbout={() => setShowAbout(true)}
+          account={account}
+          onOpenAccount={onOpenAccount}
+          onSignOut={onSignOut}
         />
       )}
     </>

--- a/src/screens/HomeScreen/components/CommandPalette.test.tsx
+++ b/src/screens/HomeScreen/components/CommandPalette.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { AccountState } from '../../../hooks/useConfig.ts';
 import type { AppConfig } from '../../../types/config.ts';
 import { mockConfig, mockHiddenModule } from '../../../test/fixtures.ts';
 import { CommandPalette } from './CommandPalette.tsx';
@@ -10,6 +11,9 @@ function renderPalette(
   onClose = vi.fn(),
   onOpenSettings = vi.fn(),
   onOpenAbout = vi.fn(),
+  account?: AccountState,
+  onOpenAccount = vi.fn(),
+  onSignOut = vi.fn(),
 ) {
   render(
     <CommandPalette
@@ -18,9 +22,12 @@ function renderPalette(
       onClose={onClose}
       onOpenSettings={onOpenSettings}
       onOpenAbout={onOpenAbout}
+      account={account}
+      onOpenAccount={onOpenAccount}
+      onSignOut={onSignOut}
     />,
   );
-  return { onSave, onClose, onOpenSettings, onOpenAbout };
+  return { onSave, onClose, onOpenSettings, onOpenAbout, onOpenAccount, onSignOut };
 }
 
 async function openAddLinkForm(user: ReturnType<typeof userEvent.setup>) {
@@ -70,6 +77,56 @@ describe('CommandPalette', () => {
 
     expect(onClose).toHaveBeenCalledOnce();
     expect(onOpenAbout).toHaveBeenCalledOnce();
+  });
+
+  it('shows Account and Sign In only while signed out, with both opening Account', async () => {
+    const user = userEvent.setup();
+    const { onClose, onOpenAccount, onSignOut } = renderPalette(
+      mockConfig,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      { status: 'signed-out' },
+    );
+
+    expect(screen.getByRole('option', { name: /^Account/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /^Sign In/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /^Sign Out/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', { name: /^Sign In/ }));
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onOpenAccount).toHaveBeenCalledOnce();
+    expect(onSignOut).not.toHaveBeenCalled();
+  });
+
+  it('shows Account and Sign Out only while signed in, and signs out immediately', async () => {
+    const user = userEvent.setup();
+    const { onClose, onOpenAccount, onSignOut } = renderPalette(
+      mockConfig,
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      vi.fn(),
+      { status: 'signed-in', userId: 'user-1', email: 'person@example.com' },
+    );
+
+    expect(screen.getByRole('option', { name: /^Account/ })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /^Sign Out/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /^Sign In/ })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('option', { name: /^Sign Out/ }));
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onSignOut).toHaveBeenCalledOnce();
+    expect(onOpenAccount).not.toHaveBeenCalled();
+  });
+
+  it('hides account commands when account sync is disabled', () => {
+    renderPalette(mockConfig, vi.fn(), vi.fn(), vi.fn(), vi.fn(), { status: 'disabled' });
+
+    expect(screen.queryByRole('option', { name: /^Account/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /^Sign In/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /^Sign Out/ })).not.toBeInTheDocument();
   });
 
   it('closes on Escape and backdrop click', async () => {

--- a/src/screens/HomeScreen/components/CommandPalette.tsx
+++ b/src/screens/HomeScreen/components/CommandPalette.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useHotkey } from '@tanstack/react-hotkeys';
+import type { AccountState } from '../../../hooks/useConfig.ts';
 import type { AppConfig, ModuleConfig } from '../../../types/config.ts';
 import { ensureProtocol, MAX_LINK_LABEL, MAX_SECTION_NAME } from '../../../utils/linkConfig.ts';
 
-type CommandId = 'add-link' | 'open-settings' | 'about';
+type CommandId = 'add-link' | 'open-settings' | 'account' | 'sign-in' | 'sign-out' | 'about';
 type PaletteView = 'commands' | 'add-link';
 
 interface CommandDefinition {
@@ -13,7 +14,7 @@ interface CommandDefinition {
   keywords: string[];
 }
 
-const COMMANDS = [
+const BASE_COMMANDS = [
   {
     id: 'add-link',
     label: 'Add Link',
@@ -34,12 +35,36 @@ const COMMANDS = [
   },
 ] satisfies readonly CommandDefinition[];
 
+const ACCOUNT_COMMAND = {
+  id: 'account',
+  label: 'Account',
+  description: 'Open your account and sync settings',
+  keywords: ['profile', 'sync', 'user'],
+} satisfies CommandDefinition;
+
+const SIGN_IN_COMMAND = {
+  id: 'sign-in',
+  label: 'Sign In',
+  description: 'Sign in to sync your new tab page',
+  keywords: ['account', 'login', 'sync'],
+} satisfies CommandDefinition;
+
+const SIGN_OUT_COMMAND = {
+  id: 'sign-out',
+  label: 'Sign Out',
+  description: 'Sign out of your synced account',
+  keywords: ['account', 'logout', 'sync'],
+} satisfies CommandDefinition;
+
 interface CommandPaletteProps {
   config: AppConfig;
   onSave: (config: AppConfig) => void;
   onClose: () => void;
   onOpenSettings: () => void;
   onOpenAbout: () => void;
+  account?: AccountState;
+  onOpenAccount?: () => void;
+  onSignOut?: () => void | Promise<void>;
 }
 
 interface AddLinkFormProps extends Pick<CommandPaletteProps, 'config' | 'onSave' | 'onClose'> {
@@ -328,6 +353,25 @@ function CommandIcon({ id }: { id: CommandId }) {
     );
   }
 
+  if (id === 'account' || id === 'sign-in') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M20 21a8 8 0 0 0-16 0" />
+        <circle cx="12" cy="7" r="4" />
+      </svg>
+    );
+  }
+
+  if (id === 'sign-out') {
+    return (
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10 17l5-5-5-5" />
+        <path d="M15 12H3" />
+        <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+      </svg>
+    );
+  }
+
   return (
     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M12 5v14" />
@@ -342,6 +386,9 @@ export function CommandPalette({
   onClose,
   onOpenSettings,
   onOpenAbout,
+  account,
+  onOpenAccount,
+  onSignOut,
 }: CommandPaletteProps) {
   const [view, setView] = useState<PaletteView>('commands');
   const [query, setQuery] = useState('');
@@ -351,17 +398,30 @@ export function CommandPalette({
   const titleId = useId();
   const listId = useId();
 
+  const commands = useMemo<CommandDefinition[]>(() => {
+    const availableCommands: CommandDefinition[] = [...BASE_COMMANDS];
+    if (!account || account.status === 'disabled' || !onOpenAccount) return availableCommands;
+
+    availableCommands.splice(2, 0, ACCOUNT_COMMAND);
+    if (account.status === 'signed-in' && onSignOut) {
+      availableCommands.splice(3, 0, SIGN_OUT_COMMAND);
+    } else if (account.status === 'signed-out') {
+      availableCommands.splice(3, 0, SIGN_IN_COMMAND);
+    }
+    return availableCommands;
+  }, [account, onOpenAccount, onSignOut]);
+
   const filteredCommands = useMemo(() => {
     const terms = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
-    if (terms.length === 0) return COMMANDS;
+    if (terms.length === 0) return commands;
 
-    return COMMANDS.filter((command) => {
+    return commands.filter((command) => {
       const haystack = [command.label, command.description, ...command.keywords]
         .join(' ')
         .toLocaleLowerCase();
       return terms.every((term) => haystack.includes(term));
     });
-  }, [query]);
+  }, [commands, query]);
 
   useHotkey('Escape', onClose, { preventDefault: true });
 
@@ -381,10 +441,20 @@ export function CommandPalette({
     }
 
     onClose();
-    if (command.id === 'open-settings') {
-      onOpenSettings();
-    } else {
-      onOpenAbout();
+    switch (command.id) {
+      case 'open-settings':
+        onOpenSettings();
+        break;
+      case 'account':
+      case 'sign-in':
+        onOpenAccount?.();
+        break;
+      case 'sign-out':
+        void onSignOut?.();
+        break;
+      case 'about':
+        onOpenAbout();
+        break;
     }
   };
 


### PR DESCRIPTION
Adds Account, Sign In, and Sign Out actions to the command palette. Account and Sign In open the existing account settings page, while Sign Out immediately invokes the existing sign-out flow. Authentication commands are shown conditionally based on account availability and signed-in state. Includes command-palette and HomeScreen coverage; lint, all 168 tests, and the production build pass.