### PR TITLE
feat: add scoped subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ npm run test:watch    # run tests in watch mode
 
 ## Configuration
 
-All configuration is managed from the built-in settings page, which has two tabs:
+All configuration is managed from the built-in settings page:
 
-- **Background** — configure background image, overlay color, opacity, and gradient
+- **General** — configure background image, overlay color, opacity, gradient, and search
 - **Links** — add, remove, rename, and reorder sections and links
+- **Subcommands** — add scoped shortcuts with predefined links or freeform URL arguments
 
 Configuration is stored in the browser's localStorage. On first load, a default `config.json` seeds the initial config. You can also import/export the full config as a base64 string from the settings header.
 

--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -1,9 +1,10 @@
 # Configuration
 
-Configuration is stored in the browser's localStorage. On first load (when no localStorage data exists), the app fetches `config.json` to seed the initial config. All subsequent changes are saved to localStorage and the seed file is not read again. The settings page has two tabs:
+Configuration is stored in the browser's localStorage. On first load (when no localStorage data exists), the app fetches `config.json` to seed the initial config. All subsequent changes are saved to localStorage and the seed file is not read again. The settings page includes:
 
-- **Background** — configure background image, overlay color, opacity, and gradient
+- **General** — configure background image, overlay color, opacity, gradient, and search
 - **Links** — add, remove, rename, and reorder sections and links
+- **Subcommands** — create scoped shortcuts with predefined links and freeform URL fields
 
 You can also import/export the full config as a base64 string from the settings header.
 
@@ -15,6 +16,7 @@ You can also import/export the full config as a base64 string from the settings 
 | `background` | `object` | Background settings (optional) |
 | `search` | `object` | Search bar settings (optional) |
 | `modules` | `array` | Array of module configurations |
+| `subcommands` | `array` | Scoped launcher commands (optional) |
 
 ## `background`
 
@@ -48,6 +50,8 @@ Optional. If missing or `enabled: false`, no search bar is shown.
 
 The search bar filters links across all modules by label (case-insensitive substring match). Pressing **Escape** clears the filter. Pressing **Enter** when exactly one link matches navigates to that link.
 
+When `search.enabled` is `false` but subcommands are configured, the launcher remains visible for subcommands and does not show ordinary link results.
+
 ## `modules[]`
 
 Each module represents a section of links on the page.
@@ -66,6 +70,49 @@ Each module represents a section of links on the page.
 | `url` | `string` | — | Link URL |
 | `label` | `string` | — | Display text |
 | `icon` | `string` | auto-fetched favicon | URL to an icon image. If omitted, a favicon is fetched from Google's favicon service. |
+
+## `subcommands[]`
+
+Subcommands are one-level scopes in the launcher. Their items do not appear in homepage modules or ordinary link searches.
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | `string` | Display name used in launcher suggestions |
+| `trigger` | `string` | Unique, case-insensitive shortcut of up to 20 letters, numbers, `_`, or `-` |
+| `items` | `array` | Predefined destinations; may be empty when `freeform` is present |
+| `freeform` | `object` | Optional ordered argument fields and URL template |
+
+Each predefined item has a required `label` and HTTP(S) `url`, plus an optional imported `icon`. A subcommand must have at least one predefined item or a valid freeform definition.
+
+Freeform fields are required positional values. Field names are unique, up to 30 letters, numbers, `_`, or `-`, and each field must appear in the template as a `{field}` placeholder. Templates may not reference unknown fields and must resolve to an HTTP(S) URL. Complete values are URL-encoded during interpolation, so spaces and `/` characters remain inside one argument.
+
+To run a subcommand, type its trigger and press **Tab**, or activate its suggestion with **Enter** or a click. Within the scope:
+
+- **Enter** opens the selected predefined item.
+- A live **Open generated destination** option appears after predefined matches when the current value completes the freeform URL. Select it, or press **Enter** when it is the only result, to open it without committing with Tab first.
+- **Tab** commits the current value to the next freeform field.
+- **Shift+Tab** returns to the previous field and selects its value.
+- **Backspace** on an empty field returns to the previous field.
+- **Escape** clears field text, or exits the scope when the field is empty.
+
+Example with both kinds of destination:
+
+```json
+{
+  "name": "GitHub Project",
+  "trigger": "ghp",
+  "items": [
+    {
+      "label": "newtab",
+      "url": "https://github.com/pablaber/newtab"
+    }
+  ],
+  "freeform": {
+    "fields": [{ "name": "repo" }],
+    "urlTemplate": "https://github.com/pablaber/{repo}"
+  }
+}
+```
 
 ## Example
 

--- a/public/config.json
+++ b/public/config.json
@@ -15,6 +15,44 @@
     "enabled": true,
     "placeholder": "Filter links..."
   },
+  "subcommands": [
+    {
+      "name": "GitHub Repository",
+      "trigger": "gh",
+      "items": [
+        { "label": "React", "url": "https://github.com/facebook/react" },
+        { "label": "TypeScript", "url": "https://github.com/microsoft/TypeScript" },
+        { "label": "Vite", "url": "https://github.com/vitejs/vite" }
+      ],
+      "freeform": {
+        "fields": [
+          { "name": "owner" },
+          { "name": "repo" }
+        ],
+        "urlTemplate": "https://github.com/{owner}/{repo}"
+      }
+    },
+    {
+      "name": "Developer Docs",
+      "trigger": "docs",
+      "items": [
+        { "label": "MDN Web Docs", "url": "https://developer.mozilla.org" },
+        { "label": "React Docs", "url": "https://react.dev" },
+        { "label": "TypeScript Docs", "url": "https://www.typescriptlang.org/docs/" }
+      ]
+    },
+    {
+      "name": "DuckDuckGo Search",
+      "trigger": "ddg",
+      "items": [],
+      "freeform": {
+        "fields": [
+          { "name": "query" }
+        ],
+        "urlTemplate": "https://duckduckgo.com/?q={query}"
+      }
+    }
+  ],
   "modules": [
     {
       "type": "links",

--- a/src/App.css
+++ b/src/App.css
@@ -131,15 +131,35 @@
   max-width: 600px;
 }
 
-.search-bar {
+.search-bar-shell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   width: 100%;
-  padding: 14px 20px;
-  font-size: 1.1rem;
-  font-family: inherit;
-  color: rgb(var(--fg));
+  min-height: 52px;
+  padding: 5px 8px;
   background: rgba(var(--fg), 0.08);
   border: 1px solid rgba(var(--fg), 0.1);
   border-radius: 12px;
+  transition: background 150ms, border-color 150ms;
+}
+
+.search-bar-shell.focused {
+  background: rgba(var(--fg), 0.12);
+  border-color: rgba(var(--fg), 0.2);
+}
+
+.search-bar {
+  flex: 1;
+  min-width: 80px;
+  width: auto;
+  padding: 8px 11px;
+  font-size: 1.1rem;
+  font-family: inherit;
+  color: rgb(var(--fg));
+  background: transparent;
+  border: none;
+  border-radius: 8px;
   outline: none;
   transition: background 150ms, border-color 150ms;
 }
@@ -149,8 +169,7 @@
 }
 
 .search-bar:focus {
-  background: rgba(var(--fg), 0.12);
-  border-color: rgba(var(--fg), 0.2);
+  background: transparent;
 }
 
 .search-bar--has-kbd {
@@ -179,6 +198,60 @@
 
 .search-bar-kbd--hidden {
   opacity: 0;
+}
+
+.search-scope-chip,
+.search-argument-chip {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 6px;
+  padding: 6px 9px;
+  color: rgba(var(--fg), 0.82);
+  background: rgba(var(--fg), 0.12);
+  border: 1px solid rgba(var(--fg), 0.12);
+  border-radius: 8px;
+  font-family: inherit;
+  font-size: 0.78rem;
+}
+
+.search-scope-chip {
+  cursor: pointer;
+}
+
+.search-scope-chip:hover {
+  background: rgba(var(--fg), 0.18);
+}
+
+.search-argument-chip {
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.search-argument-chip small {
+  color: rgba(var(--fg), 0.44);
+  font-size: 0.65rem;
+  text-transform: uppercase;
+}
+
+.search-scope-syntax {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px 0;
+  color: rgba(var(--fg), 0.42);
+  font-size: 0.72rem;
+}
+
+.search-scope-syntax code {
+  color: rgba(var(--fg), 0.68);
+  font-family: inherit;
+}
+
+.search-scope-syntax span:last-child {
+  margin-left: auto;
 }
 
 /* Search Dropdown */
@@ -240,6 +313,33 @@
   opacity: 0.4;
   flex-shrink: 0;
   margin-left: 12px;
+}
+
+.search-subcommand-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  color: rgba(var(--fg), 0.65);
+  font-size: 0.72rem;
+  font-weight: 700;
+  background: rgba(var(--fg), 0.1);
+  border-radius: 4px;
+}
+
+.search-generated-item {
+  gap: 14px;
+}
+
+.search-generated-url {
+  min-width: 0;
+  overflow: hidden;
+  color: rgba(var(--fg), 0.46);
+  font-size: 0.75rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Module Grid */
@@ -1168,6 +1268,68 @@
   font-size: 0.95rem;
 }
 
+/* Subcommands Tab */
+.config-editor-tab-toolbar,
+.subcommand-editor-group-header,
+.subcommand-heading-fields,
+.subcommand-field-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.config-editor-tab-toolbar {
+  margin-bottom: 16px;
+}
+
+.subcommand-heading-fields {
+  flex: 1;
+  min-width: 0;
+}
+
+.subcommand-heading-fields .config-editor-input:first-child {
+  flex: 1;
+}
+
+.subcommand-trigger-input {
+  width: 120px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.subcommand-editor-card .config-editor-field-error {
+  margin: 4px 0;
+}
+
+.subcommand-editor-group {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(var(--fg), 0.08);
+}
+
+.subcommand-editor-group-header {
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.subcommand-editor-group-header h3 {
+  margin: 0;
+  color: rgba(var(--fg), 0.62);
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.subcommand-freeform-editor {
+  display: grid;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.subcommand-field-row .config-editor-link-fields {
+  flex: 1;
+}
+
 /* Hosted Footer */
 .hosted-footer {
   display: flex;
@@ -1610,6 +1772,19 @@
   .config-editor-tab {
     flex: 1;
     padding-inline: 8px;
+  }
+
+  .config-editor-tabs {
+    overflow-x: auto;
+  }
+
+  .subcommand-heading-fields {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .subcommand-trigger-input {
+    width: 100%;
   }
 
   .sync-conflict-option {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ function App() {
   } = useConfig();
   const [showConfig, setShowConfig] = useState(false);
   const [configTab, setConfigTab] = useState<ConfigEditorTab>('general');
+  const [stageNewSubcommand, setStageNewSubcommand] = useState(false);
   const [previewBackground, setPreviewBackground] = useState<BackgroundConfig | null>(null);
 
   const effectiveBackground: BackgroundConfig | undefined =
@@ -48,14 +49,16 @@ function App() {
     setEditorOpen(showConfig);
   }, [setEditorOpen, showConfig]);
 
-  const openSettings = (tab: ConfigEditorTab = 'general') => {
+  const openSettings = (tab: ConfigEditorTab = 'general', stageSubcommand = false) => {
     setConfigTab(tab);
+    setStageNewSubcommand(stageSubcommand);
     setShowConfig(true);
   };
 
   const closeSettings = () => {
     setShowConfig(false);
     setPreviewBackground(null);
+    setStageNewSubcommand(false);
   };
 
   if (loading) {
@@ -79,6 +82,7 @@ function App() {
           onClose={closeSettings}
           onPreview={(bg) => setPreviewBackground(bg ?? null)}
           initialTab={configTab}
+          stageNewSubcommand={stageNewSubcommand}
           accountControls={account.status === 'disabled' ? undefined : {
             account,
             syncStatus,
@@ -107,6 +111,7 @@ function App() {
         config={config}
         onSaveConfig={setConfig}
         onOpenSettings={() => openSettings('general')}
+        onOpenSubcommands={() => openSettings('subcommands', true)}
         account={account}
         syncStatus={syncStatus}
         onOpenAccount={account.status === 'disabled' ? undefined : () => openSettings('account')}

--- a/src/screens/ConfigEditorScreen/ConfigEditorScreen.test.tsx
+++ b/src/screens/ConfigEditorScreen/ConfigEditorScreen.test.tsx
@@ -31,6 +31,30 @@ describe('ConfigEditorScreen', () => {
     expect(generalTab).not.toHaveClass('active');
   });
 
+  it('opens the Subcommands tab with a staged unsaved card', () => {
+    render(<ConfigEditor {...defaultProps} initialTab="subcommands" stageNewSubcommand />);
+
+    expect(screen.getByRole('button', { name: 'Subcommands' })).toHaveClass('active');
+    expect(screen.getByLabelText('Subcommand 1 name')).toHaveValue('');
+  });
+
+  it('preserves a subcommand draft across settings tabs', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<ConfigEditor {...defaultProps} onSave={onSave} initialTab="subcommands" stageNewSubcommand />);
+
+    await user.type(screen.getByLabelText('Subcommand 1 name'), 'Docs');
+    await user.type(screen.getByLabelText('Subcommand 1 trigger'), 'docs');
+    await user.click(screen.getByRole('button', { name: 'Add Item' }));
+    await user.type(screen.getByLabelText('Docs item 1 label'), 'Guide');
+    await user.type(screen.getByLabelText('Docs item 1 URL'), 'https://example.com');
+    await user.click(screen.getByRole('button', { name: 'General' }));
+    await user.click(screen.getByRole('button', { name: 'Subcommands' }));
+    await user.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+
+    expect((onSave.mock.calls[0][0] as AppConfig).subcommands?.[0].trigger).toBe('docs');
+  });
+
   it('shows export modal with base64 string', async () => {
     const user = userEvent.setup();
     render(<ConfigEditor {...defaultProps} />);

--- a/src/screens/ConfigEditorScreen/ConfigEditorScreen.tsx
+++ b/src/screens/ConfigEditorScreen/ConfigEditorScreen.tsx
@@ -3,6 +3,7 @@ import type { AppConfig, BackgroundConfig } from '../../types/config.ts';
 import { validateConfig } from '../../utils/configValidation.ts';
 import { GeneralTab } from './components/GeneralTab.tsx';
 import { LinksTab } from './components/LinksTab.tsx';
+import { SubcommandsTab } from './components/SubcommandsTab.tsx';
 import { AccountTab, type AccountTabProps } from './components/AccountTab.tsx';
 
 function toBase64(str: string): string {
@@ -18,7 +19,7 @@ function fromBase64(b64: string): string {
 }
 
 type ImportExportPanel = 'none' | 'export' | 'import';
-export type ConfigEditorTab = 'general' | 'links' | 'account';
+export type ConfigEditorTab = 'general' | 'links' | 'subcommands' | 'account';
 
 interface ConfigEditorProps {
   config: AppConfig;
@@ -27,6 +28,7 @@ interface ConfigEditorProps {
   onPreview: (background: BackgroundConfig | undefined) => void;
   initialTab?: ConfigEditorTab;
   accountControls?: AccountTabProps;
+  stageNewSubcommand?: boolean;
 }
 
 export function ConfigEditor({
@@ -36,14 +38,28 @@ export function ConfigEditor({
   onPreview,
   initialTab = 'general',
   accountControls,
+  stageNewSubcommand = false,
 }: ConfigEditorProps) {
   const [tab, setTab] = useState<ConfigEditorTab>(
     initialTab === 'account' && !accountControls ? 'general' : initialTab,
   );
-  const [draftConfig, setDraftConfig] = useState<AppConfig>(() => ({
-    ...config,
-    modules: config.modules.map((m) => ({ ...m, links: m.links.map((l) => ({ ...l })) })),
-  }));
+  const [draftConfig, setDraftConfig] = useState<AppConfig>(() => {
+    const subcommands = config.subcommands?.map((subcommand) => ({
+      ...subcommand,
+      items: subcommand.items.map((item) => ({ ...item })),
+      freeform: subcommand.freeform && {
+        ...subcommand.freeform,
+        fields: subcommand.freeform.fields.map((field) => ({ ...field })),
+      },
+    }));
+    return {
+      ...config,
+      modules: config.modules.map((m) => ({ ...m, links: m.links.map((l) => ({ ...l })) })),
+      subcommands: stageNewSubcommand
+        ? [{ name: '', trigger: '', items: [] }, ...(subcommands ?? [])]
+        : subcommands,
+    };
+  });
   const [activePanel, setActivePanel] = useState<ImportExportPanel>('none');
   const [exportString, setExportString] = useState('');
   const [copied, setCopied] = useState(false);
@@ -163,6 +179,12 @@ export function ConfigEditor({
         >
           Links
         </button>
+        <button
+          className={`config-editor-tab${tab === 'subcommands' ? ' active' : ''}`}
+          onClick={() => setTab('subcommands')}
+        >
+          Subcommands
+        </button>
         {accountControls && (
           <button
             className={`config-editor-tab${tab === 'account' ? ' active' : ''}`}
@@ -189,6 +211,16 @@ export function ConfigEditor({
           onSave={handleSave}
           onClose={onClose}
           onConfigChange={handleConfigChange}
+        />
+      )}
+
+      {tab === 'subcommands' && (
+        <SubcommandsTab
+          config={draftConfig}
+          onSave={handleSave}
+          onClose={onClose}
+          onConfigChange={handleConfigChange}
+          stageNew={false}
         />
       )}
 

--- a/src/screens/ConfigEditorScreen/components/SubcommandsTab.test.tsx
+++ b/src/screens/ConfigEditorScreen/components/SubcommandsTab.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { AppConfig } from '../../../types/config.ts';
+import { mockConfig, mockSubcommands } from '../../../test/fixtures.ts';
+import { SubcommandsTab } from './SubcommandsTab.tsx';
+
+const config: AppConfig = { ...mockConfig, subcommands: mockSubcommands };
+
+function renderTab(overrides: Partial<React.ComponentProps<typeof SubcommandsTab>> = {}) {
+  const props = {
+    config,
+    onSave: vi.fn(),
+    onClose: vi.fn(),
+    onConfigChange: vi.fn(),
+    ...overrides,
+  };
+  render(<SubcommandsTab {...props} />);
+  return props;
+}
+
+describe('SubcommandsTab', () => {
+  it('adds, validates, normalizes, and saves a predefined subcommand', async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderTab({ config: mockConfig });
+
+    await user.click(screen.getByRole('button', { name: 'Add Subcommand' }));
+    const card = document.querySelector('.subcommand-editor-card') as HTMLElement;
+    await user.type(within(card).getByLabelText('Subcommand 1 name'), ' Docs ');
+    await user.type(within(card).getByLabelText('Subcommand 1 trigger'), ' DOC ');
+    await user.click(within(card).getByRole('button', { name: 'Add Item' }));
+    await user.type(within(card).getByLabelText(/item 1 label/), ' Guide ');
+    await user.type(within(card).getByLabelText(/item 1 URL/), 'example.com/guide');
+    await user.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+
+    const saved = onSave.mock.calls[0][0] as AppConfig;
+    expect(saved.subcommands?.[0]).toEqual({
+      name: 'Docs',
+      trigger: 'doc',
+      items: [{ label: 'Guide', url: 'https://example.com/guide' }],
+    });
+  });
+
+  it('edits ordered freeform fields and URL templates', async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderTab({ config: mockConfig });
+
+    await user.click(screen.getByRole('button', { name: 'Add Subcommand' }));
+    const card = document.querySelector('.subcommand-editor-card') as HTMLElement;
+    await user.type(within(card).getByLabelText('Subcommand 1 name'), 'GitHub');
+    await user.type(within(card).getByLabelText('Subcommand 1 trigger'), 'GH');
+    await user.click(within(card).getByRole('checkbox', { name: 'Enable freeform URL' }));
+    await user.type(within(card).getByLabelText('GitHub field 1 name'), 'Account');
+    await user.click(within(card).getByRole('button', { name: 'Add Field' }));
+    await user.type(within(card).getByLabelText('GitHub field 2 name'), 'Repo');
+    fireEvent.change(within(card).getByPlaceholderText('https://example.com/{field}'), {
+      target: { value: 'https://github.com/{account}/{repo}' },
+    });
+    await user.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+
+    expect((onSave.mock.calls[0][0] as AppConfig).subcommands?.[0].freeform).toEqual({
+      fields: [{ name: 'account' }, { name: 'repo' }],
+      urlTemplate: 'https://github.com/{account}/{repo}',
+    });
+  });
+
+  it('reports trigger and template validation errors without saving', async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderTab({ config: mockConfig });
+
+    await user.click(screen.getByRole('button', { name: 'Add Subcommand' }));
+    const card = document.querySelector('.subcommand-editor-card') as HTMLElement;
+    await user.type(within(card).getByLabelText('Subcommand 1 name'), 'Broken');
+    await user.type(within(card).getByLabelText('Subcommand 1 trigger'), 'not valid');
+    await user.click(within(card).getByRole('checkbox', { name: 'Enable freeform URL' }));
+    await user.type(within(card).getByLabelText('Broken field 1 name'), 'repo');
+    fireEvent.change(within(card).getByPlaceholderText('https://example.com/{field}'), {
+      target: { value: 'https://example.com/{unknown}' },
+    });
+    await user.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+
+    expect(screen.getByText('Use letters, numbers, _ or -')).toBeInTheDocument();
+    expect(screen.getByText(/Use every field once or more/)).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('reorders and removes subcommands and items', async () => {
+    const user = userEvent.setup();
+    const { onSave } = renderTab();
+
+    const secondCard = document.querySelectorAll('.subcommand-editor-card')[1] as HTMLElement;
+    await user.click(within(secondCard).getByTitle('Move subcommand up'));
+    expect(screen.getByLabelText('Subcommand 1 name')).toHaveValue('GitHub');
+
+    const projectCard = document.querySelectorAll('.subcommand-editor-card')[1] as HTMLElement;
+    await user.click(within(projectCard).getAllByTitle('Remove item')[0]);
+    await user.click(screen.getAllByRole('button', { name: 'Save' })[0]);
+
+    const saved = onSave.mock.calls[0][0] as AppConfig;
+    expect(saved.subcommands?.map((value) => value.trigger)).toEqual(['gh', 'ghp']);
+    expect(saved.subcommands?.[1].items).toHaveLength(1);
+  });
+});

--- a/src/screens/ConfigEditorScreen/components/SubcommandsTab.tsx
+++ b/src/screens/ConfigEditorScreen/components/SubcommandsTab.tsx
@@ -1,0 +1,323 @@
+import { useEffect, useState } from 'react';
+import type { AppConfig, SubcommandConfig } from '../../../types/config.ts';
+import {
+  isHttpUrl,
+  isValidFreeform,
+  MAX_SUBCOMMAND_FIELD_NAME,
+  MAX_SUBCOMMAND_NAME,
+  MAX_SUBCOMMAND_TRIGGER,
+  normalizeSubcommand,
+  SUBCOMMAND_IDENTIFIER_PATTERN,
+} from '../../../utils/subcommands.ts';
+
+interface SubcommandsTabProps {
+  config: AppConfig;
+  onSave: (config: AppConfig) => void;
+  onClose: () => void;
+  onConfigChange: (config: AppConfig) => void;
+  stageNew?: boolean;
+}
+
+interface EditorError {
+  subcommand: number;
+  field: string;
+  item?: number;
+  freeformField?: number;
+  message: string;
+}
+
+const blankSubcommand = (): SubcommandConfig => ({ name: '', trigger: '', items: [] });
+
+function move<T>(values: T[], index: number, offset: -1 | 1): T[] {
+  const destination = index + offset;
+  if (destination < 0 || destination >= values.length) return values;
+  const next = [...values];
+  [next[index], next[destination]] = [next[destination], next[index]];
+  return next;
+}
+
+export function SubcommandsTab({
+  config,
+  onSave,
+  onClose,
+  onConfigChange,
+  stageNew = false,
+}: SubcommandsTabProps) {
+  const [subcommands, setSubcommands] = useState<SubcommandConfig[]>(() => {
+    const existing = (config.subcommands ?? []).map((subcommand) => ({
+      ...subcommand,
+      items: subcommand.items.map((item) => ({ ...item })),
+      freeform: subcommand.freeform && {
+        ...subcommand.freeform,
+        fields: subcommand.freeform.fields.map((field) => ({ ...field })),
+      },
+    }));
+    return stageNew ? [blankSubcommand(), ...existing] : existing;
+  });
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    onConfigChange({ ...config, subcommands });
+  }, [subcommands]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const update = (index: number, transform: (value: SubcommandConfig) => SubcommandConfig) => {
+    setSubcommands((current) => current.map((value, valueIndex) => (
+      valueIndex === index ? transform(value) : value
+    )));
+  };
+
+  const errors: EditorError[] = [];
+  subcommands.forEach((subcommand, subcommandIndex) => {
+    if (!subcommand.name.trim()) {
+      errors.push({ subcommand: subcommandIndex, field: 'name', message: 'Name is required' });
+    }
+    const trigger = subcommand.trigger.trim();
+    if (!trigger) {
+      errors.push({ subcommand: subcommandIndex, field: 'trigger', message: 'Trigger is required' });
+    } else if (!SUBCOMMAND_IDENTIFIER_PATTERN.test(trigger)) {
+      errors.push({ subcommand: subcommandIndex, field: 'trigger', message: 'Use letters, numbers, _ or -' });
+    } else if (subcommands.some((other, otherIndex) => (
+      otherIndex !== subcommandIndex
+      && other.trigger.trim().toLocaleLowerCase() === trigger.toLocaleLowerCase()
+    ))) {
+      errors.push({ subcommand: subcommandIndex, field: 'trigger', message: 'Trigger must be unique' });
+    }
+
+    if (subcommand.items.length === 0 && !subcommand.freeform) {
+      errors.push({ subcommand: subcommandIndex, field: 'actionable', message: 'Add an item or enable a freeform URL' });
+    }
+    subcommand.items.forEach((item, itemIndex) => {
+      if (!item.label.trim()) {
+        errors.push({ subcommand: subcommandIndex, item: itemIndex, field: 'item-label', message: 'Label is required' });
+      }
+      if (!item.url.trim()) {
+        errors.push({ subcommand: subcommandIndex, item: itemIndex, field: 'item-url', message: 'URL is required' });
+      } else if (!isHttpUrl(item.url.trim()) && !isHttpUrl(`https://${item.url.trim()}`)) {
+        errors.push({ subcommand: subcommandIndex, item: itemIndex, field: 'item-url', message: 'Enter a valid HTTP(S) URL' });
+      }
+    });
+
+    if (subcommand.freeform) {
+      if (subcommand.freeform.fields.length === 0) {
+        errors.push({ subcommand: subcommandIndex, field: 'fields', message: 'Add at least one field' });
+      }
+      subcommand.freeform.fields.forEach((field, fieldIndex) => {
+        const name = field.name.trim();
+        if (!name) {
+          errors.push({ subcommand: subcommandIndex, freeformField: fieldIndex, field: 'field-name', message: 'Field name is required' });
+        } else if (!SUBCOMMAND_IDENTIFIER_PATTERN.test(name)) {
+          errors.push({ subcommand: subcommandIndex, freeformField: fieldIndex, field: 'field-name', message: 'Use letters, numbers, _ or -' });
+        } else if (subcommand.freeform?.fields.some((other, otherIndex) => (
+          otherIndex !== fieldIndex
+          && other.name.trim().toLocaleLowerCase() === name.toLocaleLowerCase()
+        ))) {
+          errors.push({ subcommand: subcommandIndex, freeformField: fieldIndex, field: 'field-name', message: 'Field names must be unique' });
+        }
+      });
+      if (!subcommand.freeform.urlTemplate.trim()) {
+        errors.push({ subcommand: subcommandIndex, field: 'template', message: 'URL template is required' });
+      } else if (subcommand.freeform.fields.length > 0 && !isValidFreeform({
+        fields: subcommand.freeform.fields.map((field) => ({ name: field.name.trim() })),
+        urlTemplate: subcommand.freeform.urlTemplate.trim(),
+      })) {
+        errors.push({ subcommand: subcommandIndex, field: 'template', message: 'Use every field once or more, with no unknown placeholders, in an HTTP(S) URL' });
+      }
+    }
+  });
+
+  const errorFor = (
+    subcommand: number,
+    field: string,
+    item?: number,
+    freeformField?: number,
+  ) => errors.find((error) => (
+    error.subcommand === subcommand
+    && error.field === field
+    && error.item === item
+    && error.freeformField === freeformField
+  ))?.message;
+
+  const handleSave = () => {
+    setSubmitted(true);
+    if (errors.length > 0) return;
+    const normalized = subcommands.map(normalizeSubcommand);
+    onSave({ ...config, subcommands: normalized.length > 0 ? normalized : undefined });
+  };
+
+  return (
+    <>
+      <div className="config-editor-tab-toolbar">
+        <button className="config-editor-btn-add" onClick={() => setSubcommands([blankSubcommand(), ...subcommands])}>
+          <span aria-hidden="true">+</span>
+          Add Subcommand
+        </button>
+        <button className="config-editor-btn-add config-editor-btn-save-top" onClick={handleSave}>
+          <span aria-hidden="true">✓</span>
+          Save
+        </button>
+      </div>
+
+      {subcommands.length === 0 && (
+        <div className="config-editor-links-empty">No subcommands yet. Add one to get started.</div>
+      )}
+
+      {subcommands.map((subcommand, subcommandIndex) => (
+        <section className="config-editor-link-section subcommand-editor-card" key={subcommandIndex}>
+          <div className="config-editor-section-header">
+            <div className="subcommand-heading-fields">
+              <input
+                className="config-editor-input"
+                value={subcommand.name}
+                maxLength={MAX_SUBCOMMAND_NAME}
+                placeholder="Subcommand name"
+                aria-label={`Subcommand ${subcommandIndex + 1} name`}
+                onChange={(event) => update(subcommandIndex, (value) => ({ ...value, name: event.target.value }))}
+              />
+              <input
+                className="config-editor-input subcommand-trigger-input"
+                value={subcommand.trigger}
+                maxLength={MAX_SUBCOMMAND_TRIGGER}
+                placeholder="Trigger"
+                aria-label={`Subcommand ${subcommandIndex + 1} trigger`}
+                onChange={(event) => update(subcommandIndex, (value) => ({ ...value, trigger: event.target.value }))}
+              />
+            </div>
+            <button className="config-editor-btn-icon" disabled={subcommandIndex === 0} title="Move subcommand up" onClick={() => setSubcommands(move(subcommands, subcommandIndex, -1))}>↑</button>
+            <button className="config-editor-btn-icon" disabled={subcommandIndex === subcommands.length - 1} title="Move subcommand down" onClick={() => setSubcommands(move(subcommands, subcommandIndex, 1))}>↓</button>
+            <button className="config-editor-btn-icon danger" title="Remove subcommand" onClick={() => setSubcommands(subcommands.filter((_, index) => index !== subcommandIndex))}>×</button>
+          </div>
+          {submitted && errorFor(subcommandIndex, 'name') && <div className="config-editor-field-error">{errorFor(subcommandIndex, 'name')}</div>}
+          {submitted && errorFor(subcommandIndex, 'trigger') && <div className="config-editor-field-error">{errorFor(subcommandIndex, 'trigger')}</div>}
+          {submitted && errorFor(subcommandIndex, 'actionable') && <div className="config-editor-field-error">{errorFor(subcommandIndex, 'actionable')}</div>}
+
+          <div className="subcommand-editor-group">
+            <div className="subcommand-editor-group-header">
+              <h3>Predefined items</h3>
+              <button
+                className="config-editor-btn-add"
+                aria-label="Add Item"
+                onClick={() => update(subcommandIndex, (value) => ({
+                  ...value,
+                  items: [...value.items, { label: '', url: '' }],
+                }))}
+              >
+                + Add Item
+              </button>
+            </div>
+            {subcommand.items.map((item, itemIndex) => (
+              <div className="config-editor-link-row" key={itemIndex}>
+                <div className="config-editor-link-fields">
+                  <input
+                    className="config-editor-input"
+                    value={item.label}
+                    placeholder="Label"
+                    aria-label={`${subcommand.name || 'Subcommand'} item ${itemIndex + 1} label`}
+                    onChange={(event) => update(subcommandIndex, (value) => ({
+                      ...value,
+                      items: value.items.map((current, index) => index === itemIndex ? { ...current, label: event.target.value } : current),
+                    }))}
+                  />
+                  {submitted && errorFor(subcommandIndex, 'item-label', itemIndex) && <div className="config-editor-field-error">{errorFor(subcommandIndex, 'item-label', itemIndex)}</div>}
+                  <input
+                    className="config-editor-input"
+                    value={item.url}
+                    placeholder="URL (e.g. example.com)"
+                    aria-label={`${subcommand.name || 'Subcommand'} item ${itemIndex + 1} URL`}
+                    onChange={(event) => update(subcommandIndex, (value) => ({
+                      ...value,
+                      items: value.items.map((current, index) => index === itemIndex ? { ...current, url: event.target.value } : current),
+                    }))}
+                  />
+                  {submitted && errorFor(subcommandIndex, 'item-url', itemIndex) && <div className="config-editor-field-error">{errorFor(subcommandIndex, 'item-url', itemIndex)}</div>}
+                </div>
+                <div className="config-editor-link-actions">
+                  <button className="config-editor-btn-icon" disabled={itemIndex === 0} title="Move item up" onClick={() => update(subcommandIndex, (value) => ({ ...value, items: move(value.items, itemIndex, -1) }))}>↑</button>
+                  <button className="config-editor-btn-icon" disabled={itemIndex === subcommand.items.length - 1} title="Move item down" onClick={() => update(subcommandIndex, (value) => ({ ...value, items: move(value.items, itemIndex, 1) }))}>↓</button>
+                  <button className="config-editor-btn-icon danger" title="Remove item" onClick={() => update(subcommandIndex, (value) => ({ ...value, items: value.items.filter((_, index) => index !== itemIndex) }))}>×</button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="subcommand-editor-group">
+            <label className="config-editor-toggle">
+              <input
+                type="checkbox"
+                checked={Boolean(subcommand.freeform)}
+                onChange={(event) => update(subcommandIndex, (value) => ({
+                  ...value,
+                  freeform: event.target.checked ? { fields: [{ name: '' }], urlTemplate: '' } : undefined,
+                }))}
+              />
+              <span className="config-editor-toggle-label">Enable freeform URL</span>
+            </label>
+
+            {subcommand.freeform && (
+              <div className="subcommand-freeform-editor">
+                <div className="subcommand-editor-group-header">
+                  <h3>Ordered fields</h3>
+                  <button
+                    className="config-editor-btn-add"
+                    aria-label="Add Field"
+                    onClick={() => update(subcommandIndex, (value) => ({
+                      ...value,
+                      freeform: value.freeform && {
+                        ...value.freeform,
+                        fields: [...value.freeform.fields, { name: '' }],
+                      },
+                    }))}
+                  >
+                    + Add Field
+                  </button>
+                </div>
+                {subcommand.freeform.fields.map((field, fieldIndex) => (
+                  <div className="subcommand-field-row" key={fieldIndex}>
+                    <div className="config-editor-link-fields">
+                      <input
+                        className="config-editor-input"
+                        value={field.name}
+                        maxLength={MAX_SUBCOMMAND_FIELD_NAME}
+                        placeholder="Field name"
+                        aria-label={`${subcommand.name || 'Subcommand'} field ${fieldIndex + 1} name`}
+                        onChange={(event) => update(subcommandIndex, (value) => ({
+                          ...value,
+                          freeform: value.freeform && {
+                            ...value.freeform,
+                            fields: value.freeform.fields.map((current, index) => index === fieldIndex ? { name: event.target.value } : current),
+                          },
+                        }))}
+                      />
+                      {submitted && errorFor(subcommandIndex, 'field-name', undefined, fieldIndex) && <div className="config-editor-field-error">{errorFor(subcommandIndex, 'field-name', undefined, fieldIndex)}</div>}
+                    </div>
+                    <button className="config-editor-btn-icon" disabled={fieldIndex === 0} title="Move field up" onClick={() => update(subcommandIndex, (value) => ({ ...value, freeform: value.freeform && { ...value.freeform, fields: move(value.freeform.fields, fieldIndex, -1) } }))}>↑</button>
+                    <button className="config-editor-btn-icon" disabled={fieldIndex === subcommand.freeform!.fields.length - 1} title="Move field down" onClick={() => update(subcommandIndex, (value) => ({ ...value, freeform: value.freeform && { ...value.freeform, fields: move(value.freeform.fields, fieldIndex, 1) } }))}>↓</button>
+                    <button className="config-editor-btn-icon danger" title="Remove field" onClick={() => update(subcommandIndex, (value) => ({ ...value, freeform: value.freeform && { ...value.freeform, fields: value.freeform.fields.filter((_, index) => index !== fieldIndex) } }))}>×</button>
+                  </div>
+                ))}
+                {submitted && errorFor(subcommandIndex, 'fields') && <div className="config-editor-field-error">{errorFor(subcommandIndex, 'fields')}</div>}
+                <label className="config-editor-field">
+                  <span className="config-editor-label">URL template</span>
+                  <input
+                    className="config-editor-input"
+                    value={subcommand.freeform.urlTemplate}
+                    placeholder="https://example.com/{field}"
+                    onChange={(event) => update(subcommandIndex, (value) => ({
+                      ...value,
+                      freeform: value.freeform && { ...value.freeform, urlTemplate: event.target.value },
+                    }))}
+                  />
+                  {submitted && errorFor(subcommandIndex, 'template') && <div className="config-editor-field-error">{errorFor(subcommandIndex, 'template')}</div>}
+                </label>
+              </div>
+            )}
+          </div>
+        </section>
+      ))}
+
+      <div className="config-editor-actions">
+        <button className="config-editor-btn config-editor-btn-save" onClick={handleSave}>Save</button>
+        <button className="config-editor-btn config-editor-btn-cancel" onClick={onClose}>Cancel</button>
+      </div>
+    </>
+  );
+}

--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -12,6 +12,7 @@ interface HomeScreenProps {
   config: AppConfig;
   onSaveConfig: (config: AppConfig) => void;
   onOpenSettings: () => void;
+  onOpenSubcommands?: () => void;
   account?: AccountState;
   syncStatus?: SyncStatus;
   onOpenAccount?: () => void;
@@ -22,6 +23,7 @@ export function HomeScreen({
   config,
   onSaveConfig,
   onOpenSettings,
+  onOpenSubcommands,
   account,
   syncStatus = 'local',
   onOpenAccount,
@@ -107,6 +109,7 @@ export function HomeScreen({
           hotkeyEnabled={!showCommands && !showAbout}
           placeholder={config.search?.placeholder ?? 'Filter links...'}
           modules={config.modules}
+          subcommands={config.subcommands}
           onNavigate={handleNavigate}
         />
         {hasVisibleModules ? (
@@ -140,6 +143,7 @@ export function HomeScreen({
           onSave={onSaveConfig}
           onClose={() => setShowCommands(false)}
           onOpenSettings={onOpenSettings}
+          onOpenSubcommands={onOpenSubcommands}
           onOpenAbout={() => setShowAbout(true)}
           account={account}
           onOpenAccount={onOpenAccount}

--- a/src/screens/HomeScreen/components/CommandPalette.test.tsx
+++ b/src/screens/HomeScreen/components/CommandPalette.test.tsx
@@ -14,6 +14,7 @@ function renderPalette(
   account?: AccountState,
   onOpenAccount = vi.fn(),
   onSignOut = vi.fn(),
+  onOpenSubcommands = vi.fn(),
 ) {
   render(
     <CommandPalette
@@ -21,13 +22,14 @@ function renderPalette(
       onSave={onSave}
       onClose={onClose}
       onOpenSettings={onOpenSettings}
+      onOpenSubcommands={onOpenSubcommands}
       onOpenAbout={onOpenAbout}
       account={account}
       onOpenAccount={onOpenAccount}
       onSignOut={onSignOut}
     />,
   );
-  return { onSave, onClose, onOpenSettings, onOpenAbout, onOpenAccount, onSignOut };
+  return { onSave, onClose, onOpenSettings, onOpenAbout, onOpenAccount, onSignOut, onOpenSubcommands };
 }
 
 async function openAddLinkForm(user: ReturnType<typeof userEvent.setup>) {
@@ -67,6 +69,16 @@ describe('CommandPalette', () => {
 
     expect(onClose).toHaveBeenCalledOnce();
     expect(onOpenSettings).toHaveBeenCalledOnce();
+  });
+
+  it('opens a staged Subcommands settings card', async () => {
+    const user = userEvent.setup();
+    const { onClose, onOpenSubcommands } = renderPalette();
+
+    await user.click(screen.getByRole('option', { name: /Add Subcommand/ }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onOpenSubcommands).toHaveBeenCalledOnce();
   });
 
   it('opens About and closes the command palette', async () => {

--- a/src/screens/HomeScreen/components/CommandPalette.tsx
+++ b/src/screens/HomeScreen/components/CommandPalette.tsx
@@ -4,7 +4,7 @@ import type { AccountState } from '../../../hooks/useConfig.ts';
 import type { AppConfig, ModuleConfig } from '../../../types/config.ts';
 import { ensureProtocol, MAX_LINK_LABEL, MAX_SECTION_NAME } from '../../../utils/linkConfig.ts';
 
-type CommandId = 'add-link' | 'open-settings' | 'account' | 'sign-in' | 'sign-out' | 'about';
+type CommandId = 'add-link' | 'add-subcommand' | 'open-settings' | 'account' | 'sign-in' | 'sign-out' | 'about';
 type PaletteView = 'commands' | 'add-link';
 
 interface CommandDefinition {
@@ -26,6 +26,12 @@ const BASE_COMMANDS = [
     label: 'Open Settings',
     description: 'Customize your new tab page',
     keywords: ['config', 'preferences', 'edit'],
+  },
+  {
+    id: 'add-subcommand',
+    label: 'Add Subcommand',
+    description: 'Create a scoped launcher command',
+    keywords: ['command', 'trigger', 'url', 'shortcut'],
   },
   {
     id: 'about',
@@ -61,6 +67,7 @@ interface CommandPaletteProps {
   onSave: (config: AppConfig) => void;
   onClose: () => void;
   onOpenSettings: () => void;
+  onOpenSubcommands?: () => void;
   onOpenAbout: () => void;
   account?: AccountState;
   onOpenAccount?: () => void;
@@ -385,6 +392,7 @@ export function CommandPalette({
   onSave,
   onClose,
   onOpenSettings,
+  onOpenSubcommands,
   onOpenAbout,
   account,
   onOpenAccount,
@@ -444,6 +452,9 @@ export function CommandPalette({
     switch (command.id) {
       case 'open-settings':
         onOpenSettings();
+        break;
+      case 'add-subcommand':
+        onOpenSubcommands?.();
         break;
       case 'account':
       case 'sign-in':

--- a/src/screens/HomeScreen/components/SearchBar.test.tsx
+++ b/src/screens/HomeScreen/components/SearchBar.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { HotkeysProvider } from '@tanstack/react-hotkeys';
 import { SearchBar } from './SearchBar.tsx';
 import { scoreMatch, scoreLinkMatch } from './searchScoring.ts';
-import { mockModule, mockModuleWithHiddenLinks } from '../../../test/fixtures.ts';
+import { mockModule, mockModuleWithHiddenLinks, mockSubcommands } from '../../../test/fixtures.ts';
 import type { ModuleConfig } from '../../../types/config.ts';
 
 function renderWithHotkeys(ui: React.ReactElement) {
@@ -92,6 +92,16 @@ describe('SearchBar', () => {
       <SearchBar enabled={false} placeholder="Filter..." modules={modules} onNavigate={vi.fn()} />,
     );
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it('still renders subcommands when ordinary link search is disabled', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar enabled={false} placeholder="Filter..." modules={modules} subcommands={mockSubcommands} onNavigate={vi.fn()} />);
+
+    const input = screen.getByPlaceholderText('Run a subcommand...');
+    await user.type(input, 'ghp');
+    expect(screen.getByText('GitHub Project')).toBeInTheDocument();
+    expect(screen.queryByText('GitHub')).not.toBeInTheDocument();
   });
 
   it('shows dropdown matches when typing a query', async () => {
@@ -319,5 +329,139 @@ describe('SearchBar', () => {
     // In jsdom (Linux), Mod resolves to Control; fire Ctrl+K
     await user.keyboard('{Control>}k{/Control}');
     expect(document.activeElement).toBe(input);
+  });
+
+  it('activates an exact trigger with Tab and shows scoped items', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar enabled placeholder="Filter..." modules={modules} subcommands={mockSubcommands} onNavigate={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText('Filter...'), 'ghp');
+    await user.keyboard('{Tab}');
+
+    expect(screen.getByRole('button', { name: 'Exit GitHub Project subcommand' })).toBeInTheDocument();
+    expect(screen.getByText('newtab')).toBeInTheDocument();
+    expect(screen.getByText('<repo>')).toBeInTheDocument();
+  });
+
+  it('activates a suggested subcommand with Enter or click', async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<SearchBar enabled placeholder="Filter..." modules={[]} subcommands={mockSubcommands} onNavigate={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText('Filter...'), 'GitHub Project');
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('button', { name: 'Exit GitHub Project subcommand' })).toBeInTheDocument();
+
+    rerender(<SearchBar enabled placeholder="Filter..." modules={[]} subcommands={mockSubcommands} onNavigate={vi.fn()} />);
+    await user.click(screen.getByRole('button', { name: 'Exit GitHub Project subcommand' }));
+    await user.type(screen.getByPlaceholderText('Filter...'), 'gh');
+    await user.click(screen.getByText('GitHub Project'));
+    expect(screen.getByRole('button', { name: 'Exit GitHub Project subcommand' })).toBeInTheDocument();
+  });
+
+  it('gives predefined items Enter priority while Tab chooses freeform', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(<SearchBar enabled placeholder="Filter..." modules={[]} subcommands={mockSubcommands} onNavigate={onNavigate} />);
+
+    const input = screen.getByPlaceholderText('Filter...');
+    await user.type(input, 'ghp');
+    await user.keyboard('{Tab}');
+    await user.type(screen.getByPlaceholderText('<repo>'), 'newtab');
+    await user.keyboard('{Enter}');
+    expect(onNavigate).toHaveBeenCalledWith('https://github.com/pablaber/newtab', 'newtab');
+
+    onNavigate.mockClear();
+    await user.keyboard('{Tab}');
+    expect(screen.getByText('Open generated destination')).toBeInTheDocument();
+    expect(screen.getByText('https://github.com/pablaber/newtab')).toBeInTheDocument();
+    await user.keyboard('{Enter}');
+    expect(onNavigate).toHaveBeenCalledWith('https://github.com/pablaber/newtab', 'GitHub Project');
+  });
+
+  it('shows a live freeform destination below predefined items', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(<SearchBar enabled placeholder="Filter..." modules={[]} subcommands={mockSubcommands} onNavigate={onNavigate} />);
+
+    await user.type(screen.getByPlaceholderText('Filter...'), 'ghp');
+    await user.keyboard('{Tab}');
+    await user.type(screen.getByPlaceholderText('<repo>'), 'new');
+
+    const results = screen.getAllByRole('link');
+    expect(results[0]).toHaveTextContent('newtab');
+    expect(results[1]).toHaveTextContent('Open generated destination');
+    expect(results[1]).toHaveTextContent('https://github.com/pablaber/new');
+
+    await user.keyboard('{ArrowDown}{Enter}');
+    expect(onNavigate).toHaveBeenCalledWith('https://github.com/pablaber/new', 'GitHub Project');
+  });
+
+  it('opens the only live freeform destination with Enter without requiring Tab', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(<SearchBar enabled placeholder="Filter..." modules={[]} subcommands={mockSubcommands} onNavigate={onNavigate} />);
+
+    await user.type(screen.getByPlaceholderText('Filter...'), 'ghp');
+    await user.keyboard('{Tab}');
+    await user.type(screen.getByPlaceholderText('<repo>'), 'brand new');
+
+    expect(screen.getByRole('link')).toHaveTextContent('Open generated destination');
+    expect(screen.getByRole('link')).toHaveTextContent('https://github.com/pablaber/brand%20new');
+    await user.keyboard('{Enter}');
+    expect(onNavigate).toHaveBeenCalledWith(
+      'https://github.com/pablaber/brand%20new',
+      'GitHub Project',
+    );
+  });
+
+  it('commits multi-field values with spaces and URL-encodes spaces and slashes', async () => {
+    const user = userEvent.setup();
+    const onNavigate = vi.fn();
+    render(<SearchBar enabled placeholder="Filter..." modules={[]} subcommands={mockSubcommands} onNavigate={onNavigate} />);
+
+    await user.type(screen.getByPlaceholderText('Filter...'), 'gh');
+    await user.keyboard('{Tab}');
+    await user.type(screen.getByPlaceholderText('<account>'), 'Patrick Bacon');
+    await user.keyboard('{Tab}');
+    expect(screen.getByText('Patrick Bacon')).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText('<repo>'), 'tools/new tab');
+    await user.keyboard('{Tab}');
+
+    expect(screen.getByText('https://github.com/Patrick%20Bacon/tools%2Fnew%20tab')).toBeInTheDocument();
+    await user.keyboard('{Enter}');
+    expect(onNavigate).toHaveBeenCalledWith(
+      'https://github.com/Patrick%20Bacon/tools%2Fnew%20tab',
+      'GitHub',
+    );
+  });
+
+  it('supports Backspace, Shift+Tab, Escape, and removing the scope chip', async () => {
+    const user = userEvent.setup();
+    render(<SearchBar enabled placeholder="Filter..." modules={[]} subcommands={mockSubcommands} onNavigate={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText('Filter...'), 'gh');
+    await user.keyboard('{Tab}');
+    const accountInput = screen.getByPlaceholderText('<account>');
+    await user.type(accountInput, 'pablaber');
+    await user.keyboard('{Tab}');
+    await user.keyboard('{Backspace}');
+    expect(accountInput).toHaveValue('pablaber');
+
+    await user.keyboard('{Tab}');
+    await user.type(screen.getByPlaceholderText('<repo>'), 'draft');
+    await user.keyboard('{Shift>}{Tab}{/Shift}');
+    expect(accountInput).toHaveValue('pablaber');
+    expect(accountInput.selectionStart).toBe(0);
+    expect(accountInput.selectionEnd).toBe('pablaber'.length);
+
+    await user.keyboard('{Escape}');
+    expect(accountInput).toHaveValue('');
+    await user.keyboard('{Escape}');
+    expect(screen.queryByRole('button', { name: 'Exit GitHub subcommand' })).not.toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText('Filter...'), 'gh');
+    await user.keyboard('{Tab}');
+    await user.click(screen.getByRole('button', { name: 'Exit GitHub subcommand' }));
+    expect(screen.getByPlaceholderText('Filter...')).toHaveValue('');
   });
 });

--- a/src/screens/HomeScreen/components/SearchBar.tsx
+++ b/src/screens/HomeScreen/components/SearchBar.tsx
@@ -1,7 +1,13 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef, useMemo } from 'react';
 import { useHotkey } from '@tanstack/react-hotkeys';
-import type { LinkConfig, ModuleConfig } from '../../../types/config.ts';
-import { scoreLinkMatch } from './searchScoring.ts';
+import type {
+  LinkConfig,
+  ModuleConfig,
+  SubcommandConfig,
+  SubcommandItemConfig,
+} from '../../../types/config.ts';
+import { resolveSubcommandUrl } from '../../../utils/subcommands.ts';
+import { scoreLinkMatch, scoreMatch } from './searchScoring.ts';
 
 const MAX_RESULTS = 5;
 
@@ -14,13 +20,21 @@ interface SearchBarProps {
   hotkeyEnabled?: boolean;
   placeholder: string;
   modules: ModuleConfig[];
+  subcommands?: SubcommandConfig[];
   onNavigate: (url: string, label: string) => void;
 }
 
 interface MatchedLink extends LinkConfig {
+  kind: 'link';
   moduleTitle: string;
   favicon: string;
 }
+
+interface MatchedSubcommand extends SubcommandConfig {
+  kind: 'subcommand';
+}
+
+type GlobalMatch = MatchedLink | MatchedSubcommand;
 
 function getFaviconUrl(url: string): string {
   try {
@@ -31,112 +45,354 @@ function getFaviconUrl(url: string): string {
   }
 }
 
+function itemFavicon(item: SubcommandItemConfig): string {
+  return item.icon || getFaviconUrl(item.url);
+}
+
 export function SearchBar({
   enabled,
   hotkeyEnabled = true,
   placeholder,
   modules,
+  subcommands = [],
   onNavigate,
 }: SearchBarProps) {
   const [query, setQuery] = useState('');
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [isFocused, setIsFocused] = useState(false);
+  const [scope, setScope] = useState<SubcommandConfig | null>(null);
+  const [arguments_, setArguments] = useState<string[]>([]);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
+  const selectOnRenderRef = useRef(false);
+  const launcherEnabled = enabled || subcommands.length > 0;
 
   useHotkey('Mod+K', () => {
     inputRef.current?.focus();
-  }, { enabled: enabled && hotkeyEnabled, preventDefault: true });
+  }, { enabled: launcherEnabled && hotkeyEnabled, preventDefault: true });
 
-  const matches: MatchedLink[] = useMemo(() => {
-    if (!query) return [];
+  const globalMatches = useMemo<GlobalMatch[]>(() => {
+    if (!query || scope) return [];
+    const scored: { match: GlobalMatch; score: number }[] = [];
 
-    const scored: { link: MatchedLink; score: number }[] = [];
-
-    for (const m of modules) {
-      for (const link of m.links) {
-        const score = scoreLinkMatch(query, link.label, m.title, link.url);
-        if (score > 0) {
-          scored.push({
-            link: {
-              ...link,
-              moduleTitle: m.title,
-              favicon: link.icon || getFaviconUrl(link.url),
-            },
-            score,
-          });
+    if (enabled) {
+      for (const module of modules) {
+        for (const link of module.links) {
+          const score = scoreLinkMatch(query, link.label, module.title, link.url);
+          if (score > 0) {
+            scored.push({
+              match: {
+                ...link,
+                kind: 'link',
+                moduleTitle: module.title,
+                favicon: link.icon || getFaviconUrl(link.url),
+              },
+              score,
+            });
+          }
         }
       }
     }
 
-    scored.sort((a, b) => b.score - a.score);
-    return scored.slice(0, MAX_RESULTS).map((s) => s.link);
-  }, [query, modules]);
+    for (const subcommand of subcommands) {
+      const score = Math.max(
+        scoreMatch(query, subcommand.trigger) * 7,
+        scoreMatch(query, subcommand.name) * 5,
+      );
+      if (score > 0) scored.push({ match: { ...subcommand, kind: 'subcommand' }, score });
+    }
+
+    scored.sort((left, right) => right.score - left.score);
+    return scored.slice(0, MAX_RESULTS).map(({ match }) => match);
+  }, [enabled, modules, query, scope, subcommands]);
+
+  const scopeItems = useMemo(() => {
+    if (!scope || arguments_.length > 0) return [];
+    const normalizedQuery = query.trim().toLocaleLowerCase();
+    return scope.items.filter((item) => (
+      !normalizedQuery
+      || item.label.toLocaleLowerCase().includes(normalizedQuery)
+      || item.url.toLocaleLowerCase().includes(normalizedQuery)
+    )).slice(0, MAX_RESULTS);
+  }, [arguments_.length, query, scope]);
+
+  const generatedUrl = useMemo(() => {
+    if (!scope?.freeform || arguments_.length !== scope.freeform.fields.length) return null;
+    const values = Object.fromEntries(
+      scope.freeform.fields.map((field, index) => [field.name, arguments_[index]]),
+    );
+    return resolveSubcommandUrl(scope.freeform, values);
+  }, [arguments_, scope]);
+
+  const liveGeneratedUrl = useMemo(() => {
+    if (!scope?.freeform || !query.trim()) return null;
+    if (arguments_.length !== scope.freeform.fields.length - 1) return null;
+    const values = Object.fromEntries(
+      scope.freeform.fields.map((field, index) => [
+        field.name,
+        index < arguments_.length ? arguments_[index] : query.trim(),
+      ]),
+    );
+    return resolveSubcommandUrl(scope.freeform, values);
+  }, [arguments_, query, scope]);
+
+  const visibleResultCount = scope
+    ? (generatedUrl ? 1 : scopeItems.length + (liveGeneratedUrl ? 1 : 0))
+    : globalMatches.length;
 
   useEffect(() => {
     const item = listRef.current?.children[selectedIndex] as HTMLElement | undefined;
-    item?.scrollIntoView({ block: 'nearest' });
+    item?.scrollIntoView?.({ block: 'nearest' });
   }, [selectedIndex]);
 
-  if (!enabled) return null;
+  useLayoutEffect(() => {
+    if (!selectOnRenderRef.current) return;
+    inputRef.current?.select();
+    selectOnRenderRef.current = false;
+  }, [arguments_.length, query]);
 
-  const kbdHidden = isFocused || query.length > 0;
+  if (!launcherEnabled) return null;
+
+  const kbdHidden = isFocused || query.length > 0 || scope !== null;
   const kbdLabel = isMac() ? '⌘K' : 'Ctrl K';
+  const currentField = scope?.freeform?.fields[arguments_.length];
+  const fieldSyntax = scope?.freeform?.fields.map((field) => `<${field.name}>`).join(' ');
 
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
-    if (e.key === 'Escape') {
-      setQuery('');
-    } else if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setSelectedIndex((i) => Math.min(i + 1, matches.length - 1));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setSelectedIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === 'Enter' && matches[selectedIndex]) {
-      onNavigate(matches[selectedIndex].url, matches[selectedIndex].label);
+  function activateScope(subcommand: SubcommandConfig) {
+    setScope(subcommand);
+    setArguments([]);
+    setQuery('');
+    setSelectedIndex(0);
+    inputRef.current?.focus();
+  }
+
+  function exitScope() {
+    setScope(null);
+    setArguments([]);
+    setQuery('');
+    setSelectedIndex(0);
+    inputRef.current?.focus();
+  }
+
+  function returnToPreviousField(selectValue: boolean) {
+    if (arguments_.length === 0) return;
+    const previousValue = arguments_[arguments_.length - 1];
+    setArguments(arguments_.slice(0, -1));
+    setQuery(previousValue);
+    setSelectedIndex(0);
+    if (selectValue) selectOnRenderRef.current = true;
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (query) setQuery('');
+      else if (scope) exitScope();
+      return;
     }
+
+    if (scope && event.key === 'Backspace' && !query) {
+      event.preventDefault();
+      returnToPreviousField(false);
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      if (!scope) {
+        const exact = subcommands.find(
+          (subcommand) => subcommand.trigger.toLocaleLowerCase() === query.trim().toLocaleLowerCase(),
+        );
+        if (exact) {
+          event.preventDefault();
+          activateScope(exact);
+        }
+        return;
+      }
+
+      event.preventDefault();
+      if (event.shiftKey) {
+        returnToPreviousField(true);
+        return;
+      }
+      if (!scope.freeform || generatedUrl || !query.trim()) return;
+      setArguments([...arguments_, query.trim()]);
+      setQuery('');
+      setSelectedIndex(0);
+      return;
+    }
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setSelectedIndex((index) => Math.min(index + 1, visibleResultCount - 1));
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setSelectedIndex((index) => Math.max(index - 1, 0));
+      return;
+    }
+    if (event.key !== 'Enter') return;
+
+    if (scope) {
+      if (generatedUrl) onNavigate(generatedUrl, scope.name);
+      else if (scopeItems[selectedIndex]) {
+        const item = scopeItems[selectedIndex];
+        onNavigate(item.url, item.label);
+      } else if (liveGeneratedUrl && selectedIndex === scopeItems.length) {
+        onNavigate(liveGeneratedUrl, scope.name);
+      }
+      return;
+    }
+
+    const match = globalMatches[selectedIndex];
+    if (!match) return;
+    if (match.kind === 'subcommand') activateScope(match);
+    else onNavigate(match.url, match.label);
   }
 
   return (
     <div className="search-bar-container">
       <div className="search-bar-wrapper">
-        <input
-          ref={inputRef}
-          className={`search-bar${kbdHidden ? '' : ' search-bar--has-kbd'}`}
-          type="text"
-          placeholder={placeholder}
-          value={query}
-          onChange={(e) => { setQuery(e.target.value); setSelectedIndex(0); }}
-          onKeyDown={handleKeyDown}
-          onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
-          autoFocus
-        />
-        <kbd className={`search-bar-kbd${kbdHidden ? ' search-bar-kbd--hidden' : ''}`} aria-hidden="true">
-          {kbdLabel}
-        </kbd>
-        {matches.length > 0 && (
+        <div className={`search-bar-shell${isFocused ? ' focused' : ''}`}>
+          {scope && (
+            <button
+              type="button"
+              className="search-scope-chip"
+              onClick={exitScope}
+              aria-label={`Exit ${scope.name} subcommand`}
+            >
+              <strong>{scope.trigger}</strong>
+              <span aria-hidden="true">×</span>
+            </button>
+          )}
+          {scope?.freeform && arguments_.map((value, index) => (
+            <span className="search-argument-chip" key={`${scope.freeform?.fields[index].name}-${index}`}>
+              <small>{scope.freeform?.fields[index].name}</small>
+              {value}
+            </span>
+          ))}
+          <input
+            ref={inputRef}
+            className={`search-bar${kbdHidden ? '' : ' search-bar--has-kbd'}`}
+            type="text"
+            aria-label={scope ? `${scope.name} ${currentField?.name ?? 'destination'}` : undefined}
+            placeholder={scope
+              ? (generatedUrl ? 'Press Enter to open' : currentField ? `<${currentField.name}>` : 'Filter items...')
+              : enabled ? placeholder : 'Run a subcommand...'}
+            value={query}
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setSelectedIndex(0);
+            }}
+            onKeyDown={handleKeyDown}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
+            readOnly={Boolean(generatedUrl)}
+            autoFocus
+          />
+          <kbd className={`search-bar-kbd${kbdHidden ? ' search-bar-kbd--hidden' : ''}`} aria-hidden="true">
+            {kbdLabel}
+          </kbd>
+        </div>
+
+        {scope && fieldSyntax && (
+          <div className="search-scope-syntax">
+            <span>{scope.name}</span>
+            <code>{fieldSyntax}</code>
+            <span>Tab to commit</span>
+          </div>
+        )}
+
+        {globalMatches.length > 0 && !scope && (
           <ul className="search-dropdown" ref={listRef}>
-            {matches.map((link, i) => (
-              <li key={`${link.url}-${link.label}`}>
+            {globalMatches.map((match, index) => (
+              <li key={match.kind === 'subcommand' ? `subcommand-${match.trigger}` : `${match.url}-${match.label}`}>
                 <a
-                  className={`search-dropdown-item${i === selectedIndex ? ' selected' : ''}`}
-                  href={link.url}
-                  onClick={(e) => {
-                    e.preventDefault();
-                    onNavigate(link.url, link.label);
+                  className={`search-dropdown-item${index === selectedIndex ? ' selected' : ''}`}
+                  href={match.kind === 'link' ? match.url : '#'}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    if (match.kind === 'subcommand') activateScope(match);
+                    else onNavigate(match.url, match.label);
                   }}
                 >
                   <span className="search-dropdown-left">
-                    {link.favicon && (
-                      <img className="search-dropdown-favicon" src={link.favicon} alt="" width={16} height={16} />
+                    {match.kind === 'link' && match.favicon && (
+                      <img className="search-dropdown-favicon" src={match.favicon} alt="" width={16} height={16} />
                     )}
-                    <span className="search-dropdown-label">{link.label}</span>
+                    {match.kind === 'subcommand' && <span className="search-subcommand-icon" aria-hidden="true">›_</span>}
+                    <span className="search-dropdown-label">{match.kind === 'subcommand' ? match.name : match.label}</span>
                   </span>
-                  <span className="search-dropdown-module">{link.moduleTitle}</span>
+                  <span className="search-dropdown-module">
+                    {match.kind === 'subcommand' ? match.trigger : match.moduleTitle}
+                  </span>
                 </a>
               </li>
             ))}
+          </ul>
+        )}
+
+        {scope && (generatedUrl || liveGeneratedUrl || scopeItems.length > 0) && (
+          <ul className="search-dropdown" ref={listRef}>
+            {generatedUrl ? (
+              <li>
+                <a
+                  className="search-dropdown-item selected search-generated-item"
+                  href={generatedUrl}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    onNavigate(generatedUrl, scope.name);
+                  }}
+                >
+                  <span className="search-dropdown-left">
+                    <span className="search-subcommand-icon" aria-hidden="true">↗</span>
+                    <span className="search-dropdown-label">Open generated destination</span>
+                  </span>
+                  <span className="search-generated-url">{generatedUrl}</span>
+                </a>
+              </li>
+            ) : (
+              <>
+                {scopeItems.map((item, index) => (
+                  <li key={`${item.url}-${item.label}`}>
+                    <a
+                      className={`search-dropdown-item${index === selectedIndex ? ' selected' : ''}`}
+                      href={item.url}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        onNavigate(item.url, item.label);
+                      }}
+                    >
+                      <span className="search-dropdown-left">
+                        {itemFavicon(item) && (
+                          <img className="search-dropdown-favicon" src={itemFavicon(item)} alt="" width={16} height={16} />
+                        )}
+                        <span className="search-dropdown-label">{item.label}</span>
+                      </span>
+                      <span className="search-dropdown-module">{scope.trigger}</span>
+                    </a>
+                  </li>
+                ))}
+                {liveGeneratedUrl && (
+                  <li>
+                    <a
+                      className={`search-dropdown-item search-generated-item${selectedIndex === scopeItems.length ? ' selected' : ''}`}
+                      href={liveGeneratedUrl}
+                      onClick={(event) => {
+                        event.preventDefault();
+                        onNavigate(liveGeneratedUrl, scope.name);
+                      }}
+                    >
+                      <span className="search-dropdown-left">
+                        <span className="search-subcommand-icon" aria-hidden="true">↗</span>
+                        <span className="search-dropdown-label">Open generated destination</span>
+                      </span>
+                      <span className="search-generated-url">{liveGeneratedUrl}</span>
+                    </a>
+                  </li>
+                )}
+              </>
+            )}
           </ul>
         )}
       </div>

--- a/src/test/fixtures.ts
+++ b/src/test/fixtures.ts
@@ -1,4 +1,4 @@
-import type { AppConfig, ModuleConfig, LinkConfig, BackgroundConfig } from '../types/config.ts';
+import type { AppConfig, ModuleConfig, LinkConfig, BackgroundConfig, SubcommandConfig } from '../types/config.ts';
 
 export const mockLink: LinkConfig = {
   url: 'https://github.com',
@@ -80,3 +80,27 @@ export const mockConfigNoSearch: AppConfig = {
   version: 1,
   modules: [mockModule],
 };
+
+export const mockSubcommands: SubcommandConfig[] = [
+  {
+    name: 'GitHub Project',
+    trigger: 'ghp',
+    items: [
+      { label: 'newtab', url: 'https://github.com/pablaber/newtab' },
+      { label: 'website', url: 'https://github.com/pablaber/website' },
+    ],
+    freeform: {
+      fields: [{ name: 'repo' }],
+      urlTemplate: 'https://github.com/pablaber/{repo}',
+    },
+  },
+  {
+    name: 'GitHub',
+    trigger: 'gh',
+    items: [],
+    freeform: {
+      fields: [{ name: 'account' }, { name: 'repo' }],
+      urlTemplate: 'https://github.com/{account}/{repo}',
+    },
+  },
+];

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -37,9 +37,32 @@ export interface SearchConfig {
   placeholder?: string;
 }
 
+export interface SubcommandItemConfig {
+  label: string;
+  url: string;
+  icon?: string;
+}
+
+export interface SubcommandFieldConfig {
+  name: string;
+}
+
+export interface SubcommandFreeformConfig {
+  fields: SubcommandFieldConfig[];
+  urlTemplate: string;
+}
+
+export interface SubcommandConfig {
+  name: string;
+  trigger: string;
+  items: SubcommandItemConfig[];
+  freeform?: SubcommandFreeformConfig;
+}
+
 export interface AppConfig {
   version: number;
   background?: BackgroundConfig;
   search?: SearchConfig;
   modules: ModuleConfig[];
+  subcommands?: SubcommandConfig[];
 }

--- a/src/utils/configValidation.test.ts
+++ b/src/utils/configValidation.test.ts
@@ -1,9 +1,14 @@
 import { configsEqual, validateConfig } from './configValidation.ts';
 import { mockConfig } from '../test/fixtures.ts';
+import seedConfig from '../../public/config.json';
 
 describe('config validation', () => {
   it('accepts a complete app config', () => {
     expect(validateConfig(mockConfig)).toBe(true);
+  });
+
+  it('accepts the bundled seed config', () => {
+    expect(validateConfig(seedConfig)).toBe(true);
   });
 
   it.each([
@@ -26,5 +31,51 @@ describe('config validation', () => {
       version: mockConfig.version,
     };
     expect(configsEqual(mockConfig, sameWithReorderedTopLevel)).toBe(true);
+  });
+
+  it('accepts backward-compatible configs without subcommands and complete scoped commands', () => {
+    expect(validateConfig({ version: 1, modules: [] })).toBe(true);
+    expect(validateConfig({
+      version: 1,
+      modules: [],
+      subcommands: [{
+        name: 'GitHub',
+        trigger: 'gh',
+        items: [{ label: 'newtab', url: 'https://github.com/pablaber/newtab', icon: '/icon.png' }],
+        freeform: {
+          fields: [{ name: 'account' }, { name: 'repo' }],
+          urlTemplate: 'https://github.com/{account}/{repo}',
+        },
+      }],
+    })).toBe(true);
+  });
+
+  it.each([
+    [{ name: 'Empty', trigger: 'empty', items: [] }],
+    [
+      { name: 'One', trigger: 'GH', items: [{ label: 'a', url: 'https://example.com' }] },
+      { name: 'Two', trigger: 'gh', items: [{ label: 'b', url: 'https://example.com' }] },
+    ],
+    [{ name: 'Bad trigger', trigger: 'not valid', items: [{ label: 'a', url: 'https://example.com' }] }],
+    [{ name: 'Long trigger', trigger: 'a'.repeat(21), items: [{ label: 'a', url: 'https://example.com' }] }],
+    [{ name: 'Bad item', trigger: 'bad', items: [{ label: '', url: 'ftp://example.com' }] }],
+  ])('rejects malformed or non-actionable subcommands %#', (subcommands) => {
+    expect(validateConfig({ version: 1, modules: [], subcommands })).toBe(false);
+  });
+
+  it.each([
+    { fields: [], urlTemplate: 'https://example.com' },
+    { fields: [{ name: 'bad field' }], urlTemplate: 'https://example.com/{bad field}' },
+    { fields: [{ name: 'repo' }, { name: 'REPO' }], urlTemplate: 'https://example.com/{repo}' },
+    { fields: [{ name: 'repo' }], urlTemplate: 'https://example.com/{unknown}' },
+    { fields: [{ name: 'repo' }, { name: 'account' }], urlTemplate: 'https://example.com/{repo}' },
+    { fields: [{ name: 'repo' }], urlTemplate: 'ftp://example.com/{repo}' },
+    { fields: [{ name: 'repo' }], urlTemplate: 'https://example.com/{repo' },
+  ])('rejects invalid freeform definitions %#', (freeform) => {
+    expect(validateConfig({
+      version: 1,
+      modules: [],
+      subcommands: [{ name: 'GitHub', trigger: 'gh', items: [], freeform }],
+    })).toBe(false);
   });
 });

--- a/src/utils/configValidation.ts
+++ b/src/utils/configValidation.ts
@@ -1,4 +1,11 @@
 import type { AppConfig } from '../types/config.ts';
+import {
+  isHttpUrl,
+  isValidFreeform,
+  MAX_SUBCOMMAND_NAME,
+  MAX_SUBCOMMAND_TRIGGER,
+  SUBCOMMAND_IDENTIFIER_PATTERN,
+} from './subcommands.ts';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -42,6 +49,52 @@ export function validateConfig(value: unknown): value is AppConfig {
     if (!isRecord(value.search)) return false;
     if (typeof value.search.enabled !== 'boolean') return false;
     if (!isOptionalString(value.search.placeholder)) return false;
+  }
+
+  if (value.subcommands !== undefined) {
+    if (!Array.isArray(value.subcommands)) return false;
+    const triggers = new Set<string>();
+
+    for (const subcommand of value.subcommands) {
+      if (!isRecord(subcommand)) return false;
+      if (
+        typeof subcommand.name !== 'string'
+        || !subcommand.name.trim()
+        || subcommand.name.length > MAX_SUBCOMMAND_NAME
+        || typeof subcommand.trigger !== 'string'
+        || !subcommand.trigger
+        || subcommand.trigger.length > MAX_SUBCOMMAND_TRIGGER
+        || !SUBCOMMAND_IDENTIFIER_PATTERN.test(subcommand.trigger)
+        || !Array.isArray(subcommand.items)
+      ) return false;
+
+      const trigger = subcommand.trigger.toLocaleLowerCase();
+      if (triggers.has(trigger)) return false;
+      triggers.add(trigger);
+
+      for (const item of subcommand.items) {
+        if (!isRecord(item)) return false;
+        if (
+          typeof item.label !== 'string'
+          || !item.label.trim()
+          || typeof item.url !== 'string'
+          || !isHttpUrl(item.url)
+          || !isOptionalString(item.icon)
+        ) return false;
+      }
+
+      if (subcommand.freeform !== undefined) {
+        if (!isRecord(subcommand.freeform)) return false;
+        if (!Array.isArray(subcommand.freeform.fields)) return false;
+        if (!subcommand.freeform.fields.every((field) => (
+          isRecord(field) && typeof field.name === 'string'
+        ))) return false;
+        if (typeof subcommand.freeform.urlTemplate !== 'string') return false;
+        if (!isValidFreeform(subcommand.freeform as unknown as import('../types/config.ts').SubcommandFreeformConfig)) return false;
+      }
+
+      if (subcommand.items.length === 0 && subcommand.freeform === undefined) return false;
+    }
   }
 
   for (const module of value.modules) {

--- a/src/utils/subcommands.test.ts
+++ b/src/utils/subcommands.test.ts
@@ -1,0 +1,44 @@
+import { isValidFreeform, normalizeSubcommand, resolveSubcommandUrl } from './subcommands.ts';
+
+describe('subcommand helpers', () => {
+  it('normalizes names, identifiers, item URLs, and preserves imported icons', () => {
+    expect(normalizeSubcommand({
+      name: ' GitHub ',
+      trigger: ' GH ',
+      items: [{ label: ' Newtab ', url: ' github.com/pablaber/newtab ', icon: '/github.svg' }],
+      freeform: {
+        fields: [{ name: ' Account ' }, { name: ' Repo ' }],
+        urlTemplate: ' https://github.com/{account}/{repo} ',
+      },
+    })).toEqual({
+      name: 'GitHub',
+      trigger: 'gh',
+      items: [{ label: 'Newtab', url: 'https://github.com/pablaber/newtab', icon: '/github.svg' }],
+      freeform: {
+        fields: [{ name: 'account' }, { name: 'repo' }],
+        urlTemplate: 'https://github.com/{account}/{repo}',
+      },
+    });
+  });
+
+  it('encodes each complete value before interpolation', () => {
+    expect(resolveSubcommandUrl(
+      {
+        fields: [{ name: 'account' }, { name: 'repo' }],
+        urlTemplate: 'https://github.com/{account}/{repo}',
+      },
+      { account: 'Patrick Bacon', repo: 'tools/new tab' },
+    )).toBe('https://github.com/Patrick%20Bacon/tools%2Fnew%20tab');
+  });
+
+  it('requires complete placeholder coverage', () => {
+    expect(isValidFreeform({
+      fields: [{ name: 'account' }, { name: 'repo' }],
+      urlTemplate: 'https://github.com/{account}/{repo}',
+    })).toBe(true);
+    expect(isValidFreeform({
+      fields: [{ name: 'account' }, { name: 'repo' }],
+      urlTemplate: 'https://github.com/{account}',
+    })).toBe(false);
+  });
+});

--- a/src/utils/subcommands.ts
+++ b/src/utils/subcommands.ts
@@ -1,0 +1,87 @@
+import type {
+  SubcommandConfig,
+  SubcommandFreeformConfig,
+} from '../types/config.ts';
+import { ensureProtocol } from './linkConfig.ts';
+
+export const MAX_SUBCOMMAND_NAME = 50;
+export const MAX_SUBCOMMAND_TRIGGER = 20;
+export const MAX_SUBCOMMAND_FIELD_NAME = 30;
+export const SUBCOMMAND_IDENTIFIER_PATTERN = /^[a-zA-Z0-9_-]+$/;
+
+export function isHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function templatePlaceholders(template: string): string[] | null {
+  const placeholders = Array.from(template.matchAll(/\{([^{}]+)\}/g), (match) => match[1]);
+  const remainder = template.replace(/\{[^{}]+\}/g, '');
+  return /[{}]/.test(remainder) ? null : placeholders;
+}
+
+export function isValidFreeform(freeform: SubcommandFreeformConfig): boolean {
+  if (!Array.isArray(freeform.fields) || freeform.fields.length === 0) return false;
+  if (typeof freeform.urlTemplate !== 'string' || !freeform.urlTemplate.trim()) return false;
+
+  const names = freeform.fields.map((field) => field.name);
+  if (names.some((name) => (
+    typeof name !== 'string'
+    || !name
+    || name.length > MAX_SUBCOMMAND_FIELD_NAME
+    || !SUBCOMMAND_IDENTIFIER_PATTERN.test(name)
+  ))) return false;
+  if (new Set(names.map((name) => name.toLocaleLowerCase())).size !== names.length) return false;
+
+  const placeholders = templatePlaceholders(freeform.urlTemplate);
+  if (!placeholders) return false;
+  const normalizedNames = names.map((name) => name.toLocaleLowerCase());
+  const normalizedPlaceholders = placeholders.map((name) => name.toLocaleLowerCase());
+  if (normalizedPlaceholders.some((name) => !normalizedNames.includes(name))) return false;
+  if (normalizedNames.some((name) => !normalizedPlaceholders.includes(name))) return false;
+
+  const sampleValues = Object.fromEntries(normalizedNames.map((name) => [name, 'value']));
+  return isHttpUrl(resolveSubcommandUrl(
+    {
+      fields: freeform.fields.map((field) => ({ name: field.name.toLocaleLowerCase() })),
+      urlTemplate: freeform.urlTemplate.trim(),
+    },
+    sampleValues,
+  ));
+}
+
+export function resolveSubcommandUrl(
+  freeform: SubcommandFreeformConfig,
+  values: Record<string, string>,
+): string {
+  return freeform.urlTemplate.replace(/\{([^{}]+)\}/g, (_, rawName: string) => (
+    encodeURIComponent(values[rawName.toLocaleLowerCase()] ?? '')
+  ));
+}
+
+export function normalizeSubcommand(subcommand: SubcommandConfig): SubcommandConfig {
+  const normalized: SubcommandConfig = {
+    name: subcommand.name.trim(),
+    trigger: subcommand.trigger.trim().toLocaleLowerCase(),
+    items: subcommand.items.map((item) => ({
+      ...item,
+      label: item.label.trim(),
+      url: ensureProtocol(item.url),
+    })),
+  };
+
+  if (subcommand.freeform) {
+    normalized.freeform = {
+      fields: subcommand.freeform.fields.map((field) => ({
+        name: field.name.trim().toLocaleLowerCase(),
+      })),
+      urlTemplate: subcommand.freeform.urlTemplate.trim(),
+    };
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
Adds configurable one-level subcommands with predefined destinations and URL-template-based freeform fields, including validation, normalization, persistence, import/export, and sample seed data. Extends the launcher with scoped suggestions, argument chips, keyboard navigation, live generated destinations, and support when ordinary link search is disabled. Adds Subcommands settings CRUD and reordering plus Command Palette staging, documentation, and comprehensive coverage. Verification: npm run lint, npm run test (200 tests), and npm run build.