### PR TITLE
fix: improve favicon lookup for page urls

### DIFF
--- a/src/screens/HomeScreen/HomeScreen.tsx
+++ b/src/screens/HomeScreen/HomeScreen.tsx
@@ -3,6 +3,7 @@ import { useHotkey } from '@tanstack/react-hotkeys';
 import type { AppConfig } from '../../types/config.ts';
 import type { AccountState, SyncStatus } from '../../hooks/useConfig.ts';
 import { isHosted } from '../../env.ts';
+import { getFaviconUrl } from '../../utils/favicon.ts';
 import { SearchBar } from './components/SearchBar.tsx';
 import { ModuleGrid } from './components/ModuleGrid.tsx';
 import { AboutModal } from './components/AboutModal.tsx';
@@ -51,11 +52,7 @@ export function HomeScreen({
   );
 
   if (navigating) {
-    let favicon = '';
-    try {
-      const domain = new URL(navigating.url).hostname;
-      favicon = `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
-    } catch { /* ignore */ }
+    const favicon = getFaviconUrl(navigating.url);
 
     return (
       <div className="navigating">

--- a/src/screens/HomeScreen/components/CommandPalette.tsx
+++ b/src/screens/HomeScreen/components/CommandPalette.tsx
@@ -3,6 +3,7 @@ import { useHotkey } from '@tanstack/react-hotkeys';
 import type { AccountState } from '../../../hooks/useConfig.ts';
 import type { AppConfig, LinkConfig, ModuleConfig } from '../../../types/config.ts';
 import { ensureProtocol, MAX_LINK_LABEL, MAX_SECTION_NAME } from '../../../utils/linkConfig.ts';
+import { getFaviconUrl } from '../../../utils/favicon.ts';
 import { scoreLinkMatch } from './searchScoring.ts';
 
 type CommandId = 'add-link' | 'remove-links' | 'add-subcommand' | 'open-settings' | 'account' | 'sign-in' | 'sign-out' | 'about';
@@ -362,12 +363,7 @@ interface RemoveLinkMatch {
 
 function faviconUrl(link: LinkConfig): string {
   if (link.icon) return link.icon;
-
-  try {
-    return `https://www.google.com/s2/favicons?domain=${new URL(link.url).hostname}&sz=32`;
-  } catch {
-    return '';
-  }
+  return getFaviconUrl(link.url);
 }
 
 function RemoveLinks({ config, onSave, onClose, onBack }: RemoveLinksProps) {

--- a/src/screens/HomeScreen/components/LinkItem.test.tsx
+++ b/src/screens/HomeScreen/components/LinkItem.test.tsx
@@ -15,7 +15,7 @@ describe('LinkItem', () => {
     expect(img).toBeInTheDocument();
     expect(img).toHaveAttribute(
       'src',
-      'https://www.google.com/s2/favicons?domain=github.com&sz=32',
+      'https://www.google.com/s2/favicons?domain_url=https%3A%2F%2Fgithub.com%2F&sz=32',
     );
   });
 

--- a/src/screens/HomeScreen/components/LinkItem.tsx
+++ b/src/screens/HomeScreen/components/LinkItem.tsx
@@ -1,17 +1,9 @@
 import type { LinkConfig } from '../../../types/config.ts';
+import { getFaviconUrl } from '../../../utils/favicon.ts';
 
 interface LinkItemProps {
   link: LinkConfig;
   onNavigate: (url: string, label: string) => void;
-}
-
-function getFaviconUrl(url: string): string {
-  try {
-    const domain = new URL(url).hostname;
-    return `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
-  } catch {
-    return '';
-  }
 }
 
 export function LinkItem({ link, onNavigate }: LinkItemProps) {

--- a/src/screens/HomeScreen/components/SearchBar.tsx
+++ b/src/screens/HomeScreen/components/SearchBar.tsx
@@ -7,6 +7,7 @@ import type {
   SubcommandItemConfig,
 } from '../../../types/config.ts';
 import { resolveSubcommandUrl } from '../../../utils/subcommands.ts';
+import { getFaviconUrl } from '../../../utils/favicon.ts';
 import { scoreLinkMatch, scoreMatch } from './searchScoring.ts';
 
 const MAX_RESULTS = 5;
@@ -35,15 +36,6 @@ interface MatchedSubcommand extends SubcommandConfig {
 }
 
 type GlobalMatch = MatchedLink | MatchedSubcommand;
-
-function getFaviconUrl(url: string): string {
-  try {
-    const domain = new URL(url).hostname;
-    return `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
-  } catch {
-    return '';
-  }
-}
 
 function itemFavicon(item: SubcommandItemConfig): string {
   return item.icon || getFaviconUrl(item.url);

--- a/src/utils/favicon.test.ts
+++ b/src/utils/favicon.test.ts
@@ -1,0 +1,13 @@
+import { getFaviconUrl } from './favicon.ts';
+
+describe('getFaviconUrl', () => {
+  it('passes the complete page URL to the favicon service', () => {
+    expect(getFaviconUrl('https://my.dart.bank/login')).toBe(
+      'https://www.google.com/s2/favicons?domain_url=https%3A%2F%2Fmy.dart.bank%2Flogin&sz=32',
+    );
+  });
+
+  it('returns an empty string for an invalid URL', () => {
+    expect(getFaviconUrl('not a URL')).toBe('');
+  });
+});

--- a/src/utils/favicon.ts
+++ b/src/utils/favicon.ts
@@ -1,0 +1,8 @@
+export function getFaviconUrl(url: string): string {
+  try {
+    const pageUrl = new URL(url).href;
+    return `https://www.google.com/s2/favicons?domain_url=${encodeURIComponent(pageUrl)}&sz=32`;
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
Use Google's domain_url favicon lookup with each bookmark's complete, URL-encoded page URL so icons can be discovered for path-specific pages. Centralize favicon URL construction and reuse it across bookmark cards, search results, command results, and the navigation state while preserving custom icon overrides. Add focused tests for complete page URLs, invalid inputs, and rendered favicon URLs. Verification: npm run lint, npm run test (205 tests), and npm run build.