### PR TITLE
feat: cache new tab startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ All configuration is managed from the built-in settings page:
 
 Configuration is stored in the browser's localStorage. On first load, a default `config.json` seeds the initial config. You can also import/export the full config as a base64 string from the settings header.
 
+Production builds also install a small service worker. After the first visit, it serves the cached app shell immediately while checking for an updated version in the background. The most recently displayed validated configuration is cached separately, so account initialization does not block the new-tab screen from rendering. Cache headers for both the Docker image and Cloudflare Pages keep the worker and HTML fresh while allowing fingerprinted assets to remain cached.
+
 On [thenewtab.app](https://thenewtab.app), approved beta users can optionally sign in with an email code to sync their config across browsers. Signing in is not required: guest configs remain local to the browser, and signing out restores the browser's guest config. Self-hosted builds remain local-only by default.
 
 For the full config file schema and examples, see [docs/config-file.md](docs/config-file.md).

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -5,6 +5,7 @@ server {
 
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-cache";
     }
 
     location /assets/ {

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,14 @@
+/
+  Cache-Control: no-cache
+
+/index.html
+  Cache-Control: no-cache
+
+/sw.js
+  Cache-Control: no-cache
+
+/config.json
+  Cache-Control: no-cache
+
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,76 @@
+const CACHE_NAME = 'newtab-shell-v1';
+const APP_SHELL = ['/', '/config.json', '/newtab-transparent.png'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.addAll(APP_SHELL))
+      .then(() => self.skipWaiting()),
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys()
+      .then((keys) => Promise.all(
+        keys
+          .filter((key) => key.startsWith('newtab-shell-') && key !== CACHE_NAME)
+          .map((key) => caches.delete(key)),
+      ))
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  if (request.mode === 'navigate') {
+    const refresh = fetch(request).then(async (response) => {
+      if (response.ok) {
+        const cache = await caches.open(CACHE_NAME);
+        await cache.put('/', response.clone());
+      }
+      return response;
+    });
+
+    event.waitUntil(refresh.catch(() => undefined));
+    event.respondWith(
+      caches.match('/').then((cached) => cached ?? refresh),
+    );
+    return;
+  }
+
+  if (url.pathname.startsWith('/assets/')) {
+    event.respondWith(
+      caches.match(request).then(async (cached) => {
+        if (cached) return cached;
+
+        const response = await fetch(request);
+        if (response.ok) {
+          const cache = await caches.open(CACHE_NAME);
+          await cache.put(request, response.clone());
+        }
+        return response;
+      }),
+    );
+    return;
+  }
+
+  if (url.pathname === '/config.json') {
+    event.respondWith(
+      fetch(request)
+        .then(async (response) => {
+          if (response.ok) {
+            const cache = await caches.open(CACHE_NAME);
+            await cache.put(request, response.clone());
+          }
+          return response;
+        })
+        .catch(async () => (await caches.match(request)) ?? Response.error()),
+    );
+  }
+});

--- a/src/hooks/useConfig.test.ts
+++ b/src/hooks/useConfig.test.ts
@@ -5,6 +5,7 @@ import type { SyncBackend } from '../services/syncBackend.ts';
 import type { AppConfig } from '../types/config.ts';
 
 const STORAGE_KEY = 'newtab-config';
+const ACTIVE_STORAGE_KEY = 'newtab-active-config';
 const TEST_USER = { id: 'user-123', email: 'person@example.com' };
 const FIRST_SYNC = '2026-08-12T12:00:00.000Z';
 
@@ -34,6 +35,28 @@ describe('useConfig', () => {
     expect(result.current.config).toEqual(mockConfig);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
+  });
+
+  it('shows the last active config while account initialization runs', async () => {
+    const activeConfig: AppConfig = { ...mockConfig, version: 2 };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(mockConfig));
+    localStorage.setItem(ACTIVE_STORAGE_KEY, JSON.stringify(activeConfig));
+
+    let resolveCurrentUser: ((user: null) => void) | undefined;
+    const backend = createBackend({
+      getCurrentUser: vi.fn().mockImplementation(() => new Promise<null>((resolve) => {
+        resolveCurrentUser = resolve;
+      })),
+    });
+
+    const { result } = renderHook(() => useConfig({ backend }));
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.config).toEqual(activeConfig);
+
+    act(() => resolveCurrentUser?.(null));
+    await waitFor(() => expect(result.current.config).toEqual(mockConfig));
+    expect(JSON.parse(localStorage.getItem(ACTIVE_STORAGE_KEY)!)).toEqual(mockConfig);
   });
 
   it('fetches /config.json when localStorage is empty', async () => {
@@ -137,6 +160,7 @@ describe('useConfig', () => {
     expect(result.current.config).toEqual(remoteConfig);
     expect(result.current.initialSyncConflict).toBeNull();
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!)).toEqual(mockConfig);
+    expect(JSON.parse(localStorage.getItem(ACTIVE_STORAGE_KEY)!)).toEqual(remoteConfig);
   });
 
   it('asks before replacing two customized first-sync configs and preserves the guest copy', async () => {

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -9,6 +9,7 @@ import {
 } from '../services/syncBackend.ts';
 
 const GUEST_STORAGE_KEY = 'newtab-config';
+const ACTIVE_STORAGE_KEY = 'newtab-active-config';
 const ACCOUNT_STORAGE_PREFIX = 'newtab-account-config:';
 
 interface AccountCache {
@@ -72,6 +73,14 @@ function saveStoredConfig(key: string, config: AppConfig): void {
   localStorage.setItem(key, JSON.stringify(config));
 }
 
+function saveActiveConfig(config: AppConfig): void {
+  try {
+    saveStoredConfig(ACTIVE_STORAGE_KEY, config);
+  } catch {
+    // The active snapshot is only a best-effort startup optimization.
+  }
+}
+
 function accountStorageKey(userId: string): string {
   return `${ACCOUNT_STORAGE_PREFIX}${userId}`;
 }
@@ -111,9 +120,12 @@ export function useConfig(options?: UseConfigOptions): UseConfigResult {
     && Object.prototype.hasOwnProperty.call(options, 'backend');
   const syncConfigured = hasBackendOverride ? options.backend !== null : isSyncAvailable;
   const [initialGuest] = useState(() => loadStoredConfig(GUEST_STORAGE_KEY));
+  const [initialConfig] = useState(
+    () => loadStoredConfig(ACTIVE_STORAGE_KEY) ?? initialGuest,
+  );
 
-  const [config, setConfigState] = useState<AppConfig | null>(initialGuest);
-  const [loading, setLoading] = useState(syncConfigured || initialGuest === null);
+  const [config, setConfigState] = useState<AppConfig | null>(initialConfig);
+  const [loading, setLoading] = useState(initialConfig === null);
   const [error, setError] = useState<string | null>(null);
   const [account, setAccount] = useState<AccountState>(
     syncConfigured ? { status: 'signed-out' } : { status: 'disabled' },
@@ -136,6 +148,7 @@ export function useConfig(options?: UseConfigOptions): UseConfigResult {
   const conflictUserRef = useRef<AccountUser | null>(null);
 
   const applyConfig = useCallback((nextConfig: AppConfig) => {
+    saveActiveConfig(nextConfig);
     setConfigState(nextConfig);
   }, []);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { HotkeysProvider } from '@tanstack/react-hotkeys'
 import './index.css'
 import App from './App.tsx'
+import { registerServiceWorker } from './serviceWorker.ts'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -11,3 +12,5 @@ createRoot(document.getElementById('root')!).render(
     </HotkeysProvider>
   </StrictMode>,
 )
+
+if (import.meta.env.PROD) registerServiceWorker()

--- a/src/serviceWorker.test.ts
+++ b/src/serviceWorker.test.ts
@@ -1,0 +1,30 @@
+import { registerServiceWorker } from './serviceWorker.ts';
+
+describe('registerServiceWorker', () => {
+  const originalServiceWorker = Object.getOwnPropertyDescriptor(navigator, 'serviceWorker');
+
+  afterEach(() => {
+    if (originalServiceWorker) {
+      Object.defineProperty(navigator, 'serviceWorker', originalServiceWorker);
+    } else {
+      Reflect.deleteProperty(navigator, 'serviceWorker');
+    }
+  });
+
+  it('registers the app-shell worker after the page finishes loading', async () => {
+    const register = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'serviceWorker', {
+      configurable: true,
+      value: { register },
+    });
+
+    registerServiceWorker();
+    window.dispatchEvent(new Event('load'));
+    await Promise.resolve();
+
+    expect(register).toHaveBeenCalledWith('/sw.js', {
+      scope: '/',
+      updateViaCache: 'none',
+    });
+  });
+});

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -1,0 +1,15 @@
+export function registerServiceWorker(): void {
+  if (!('serviceWorker' in navigator)) return;
+
+  const register = () => {
+    void navigator.serviceWorker.register('/sw.js', {
+      scope: '/',
+      updateViaCache: 'none',
+    }).catch(() => {
+      // Caching is an optional performance enhancement; startup must never depend on it.
+    });
+  };
+
+  if (document.readyState === 'complete') register();
+  else window.addEventListener('load', register, { once: true });
+}


### PR DESCRIPTION
Adds a production service worker that serves the cached app shell immediately and refreshes it in the background. Restores the last validated active configuration synchronously while account sync initializes, with Cloudflare Pages and nginx cache headers that keep HTML and the worker fresh while preserving immutable asset caching. Adds focused service-worker and config-cache coverage, documents the behavior, and passes lint, all 207 tests, and the production build.