### PR TITLE
fix: align config schema, editor, renderer, and documentation

### DIFF
--- a/docs/config-file.md
+++ b/docs/config-file.md
@@ -27,6 +27,7 @@ All fields are optional.
 | `imageUrl` | `string` | — | URL to a background image. If empty/missing, solid color is used. |
 | `color` | `string` | `"#1a1a2e"` | Fallback background color and overlay color (also the first gradient color) |
 | `opacity` | `number` | `0.4` | Opacity of the color overlay on top of the image (0–1) |
+| `foreground` | `string` | `"auto"` | Text color: `"auto"` derives it from the background's luminance, `"light"` and `"dark"` force it |
 | `gradient` | `object` | — | Gradient settings (optional, see below) |
 
 ## `background.gradient`
@@ -48,7 +49,22 @@ Optional. If missing or `enabled: false`, no search bar is shown.
 | `enabled` | `boolean` | `false` | Whether to show the search/filter bar |
 | `placeholder` | `string` | `"Filter links..."` | Placeholder text for the input |
 
-The search bar filters links across all modules by label (case-insensitive substring match). Pressing **Escape** clears the filter. Pressing **Enter** when exactly one link matches navigates to that link.
+Both fields can be changed from **Settings → General → Search**. Turning search off keeps the configured placeholder so it is restored when search is turned back on.
+
+### Search behavior
+
+The launcher scores every link across all modules against the query and shows the five highest-scoring results, best match first. Each result is scored on three fields with different weights — label (×3), section title (×2), and URL (×1) — and each field is compared both literally and with non-alphanumeric characters stripped, so `zwift power` matches `zwiftpower`. Exact matches rank above prefix matches, which rank above substring matches; earlier matches within a field rank higher.
+
+A query with multiple words requires every word to match at least one field, and the result is scored on the average of the per-word scores. This lets `fitness strava` match a link labeled `Strava` inside a section titled `Fitness`. All comparisons are case-insensitive.
+
+Hidden links and links in hidden sections are still searchable even though they are not shown on the homepage.
+
+Keyboard behavior:
+
+- **Cmd/Ctrl+K** focuses the launcher.
+- **Arrow Up/Down** moves through results.
+- **Enter** opens the selected result, or enters the scope when the selected result is a subcommand.
+- **Escape** clears the query.
 
 When `search.enabled` is `false` but subcommands are configured, the launcher remains visible for subcommands and does not show ordinary link results.
 
@@ -60,8 +76,12 @@ Each module represents a section of links on the page.
 |---|---|---|---|
 | `type` | `string` | — | Module type (currently only `"links"`) |
 | `title` | `string` | — | Section heading |
-| `columns` | `number` | `3` | Number of columns in the link grid |
+| `hidden` | `boolean` | `false` | Hides the whole section from the homepage. Its links remain searchable. |
 | `links` | `array` | — | Array of link objects |
+
+Sections are laid out in a responsive grid that fits as many columns as the viewport allows, and the links inside a section wrap to fill the available width. The column count is not configurable.
+
+> **Removed:** `modules[].columns` was documented but never implemented. It is dropped from any config that still contains it the next time that config is loaded or imported, and no layout changes as a result.
 
 ## `modules[].links[]`
 
@@ -70,6 +90,7 @@ Each module represents a section of links on the page.
 | `url` | `string` | — | Link URL |
 | `label` | `string` | — | Display text |
 | `icon` | `string` | auto-fetched favicon | URL to an icon image. If omitted, a favicon is fetched from Google's favicon service. |
+| `hidden` | `boolean` | `false` | Hides the link from the homepage. It remains searchable. |
 
 ## `subcommands[]`
 
@@ -137,7 +158,6 @@ Example with both kinds of destination:
     {
       "type": "links",
       "title": "Favorites",
-      "columns": 3,
       "links": [
         { "url": "https://github.com", "label": "GitHub" },
         { "url": "https://news.ycombinator.com", "label": "Hacker News" },

--- a/public/config.json
+++ b/public/config.json
@@ -57,7 +57,6 @@
     {
       "type": "links",
       "title": "⭐ Favorites",
-      "columns": 3,
       "links": [
         { "url": "https://github.com", "label": "GitHub" },
         { "url": "https://news.ycombinator.com", "label": "Hacker News" },
@@ -69,7 +68,6 @@
     {
       "type": "links",
       "title": "🛠️ Tools",
-      "columns": 3,
       "links": [
         { "url": "https://calendar.google.com", "label": "Google Calendar" },
         { "url": "https://notion.so", "label": "Notion" },
@@ -80,7 +78,6 @@
     {
       "type": "links",
       "title": "🔭 Discover",
-      "columns": 3,
       "links": [
         { "url": "https://tastinggrounds.com", "label": "Tasting Grounds" },
         { "url": "https://wikipedia.org", "label": "Wikipedia" },
@@ -90,7 +87,6 @@
     {
       "type": "links",
       "title": "📰 News",
-      "columns": 3,
       "links": [
         { "url": "https://techcrunch.com", "label": "TechCrunch" },
         { "url": "https://arstechnica.com", "label": "Ars Technica" },

--- a/src/hooks/useConfig.test.ts
+++ b/src/hooks/useConfig.test.ts
@@ -37,6 +37,34 @@ describe('useConfig', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('migrates removed fields out of a stored config', () => {
+    const legacyConfig = {
+      ...mockConfig,
+      modules: mockConfig.modules.map((module) => ({ ...module, columns: 3 })),
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(legacyConfig));
+
+    const { result } = renderHook(() => useConfig());
+
+    expect(result.current.config).toEqual(mockConfig);
+  });
+
+  it('migrates removed fields out of the fetched seed config', async () => {
+    const legacySeed = {
+      ...mockConfig,
+      modules: mockConfig.modules.map((module) => ({ ...module, columns: 3 })),
+    };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify(legacySeed), { status: 200 }),
+    );
+
+    const { result } = renderHook(() => useConfig());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.config).toEqual(mockConfig);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify(mockConfig));
+  });
+
   it('shows the last active config while account initialization runs', async () => {
     const activeConfig: AppConfig = { ...mockConfig, version: 2 };
     localStorage.setItem(STORAGE_KEY, JSON.stringify(mockConfig));

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { AppConfig } from '../types/config.ts';
-import { configsEqual, validateConfig } from '../utils/configValidation.ts';
+import { configsEqual, parseConfig } from '../utils/configValidation.ts';
 import { isSyncAvailable } from '../env.ts';
 import {
   getSyncBackend,
@@ -62,8 +62,7 @@ function loadStoredConfig(key: string): AppConfig | null {
   try {
     const raw = localStorage.getItem(key);
     if (!raw) return null;
-    const parsed: unknown = JSON.parse(raw);
-    return validateConfig(parsed) ? parsed : null;
+    return parseConfig(JSON.parse(raw));
   } catch {
     return null;
   }
@@ -90,11 +89,12 @@ function loadAccountCache(userId: string): AccountCache | null {
     const raw = localStorage.getItem(accountStorageKey(userId));
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<AccountCache>;
-    if (!validateConfig(parsed.config)) return null;
+    const config = parseConfig(parsed.config);
+    if (!config) return null;
     if (parsed.remoteUpdatedAt !== null && typeof parsed.remoteUpdatedAt !== 'string') return null;
     if (typeof parsed.dirty !== 'boolean') return null;
     return {
-      config: parsed.config,
+      config,
       remoteUpdatedAt: parsed.remoteUpdatedAt,
       dirty: parsed.dirty,
     };
@@ -110,8 +110,8 @@ function saveAccountCache(userId: string, cache: AccountCache): void {
 async function fetchDefaultConfig(): Promise<AppConfig> {
   const response = await fetch('/config.json');
   if (!response.ok) throw new Error(`Failed to load config: ${response.status}`);
-  const data: unknown = await response.json();
-  if (!validateConfig(data)) throw new Error('The default configuration is invalid.');
+  const data = parseConfig(await response.json());
+  if (!data) throw new Error('The default configuration is invalid.');
   return data;
 }
 
@@ -222,7 +222,8 @@ export function useConfig(options?: UseConfigOptions): UseConfigResult {
         await queuePush(user.id);
         return;
       }
-      if (!validateConfig(remote.config)) {
+      const remoteConfig = parseConfig(remote.config);
+      if (!remoteConfig) {
         throw new Error('The synced configuration is invalid.');
       }
 
@@ -230,14 +231,14 @@ export function useConfig(options?: UseConfigOptions): UseConfigResult {
         || Date.parse(remote.updatedAt) > Date.parse(cache.remoteUpdatedAt);
       if (remoteIsNewer) {
         saveAccountCache(user.id, {
-          config: remote.config,
+          config: remoteConfig,
           remoteUpdatedAt: remote.updatedAt,
           dirty: false,
         });
         if (
           currentUserRef.current?.id === user.id
-          && !configsEqual(cache.config, remote.config)
-        ) applyConfig(remote.config);
+          && !configsEqual(cache.config, remoteConfig)
+        ) applyConfig(remoteConfig);
       }
 
       if (currentUserRef.current?.id === user.id) {
@@ -327,7 +328,8 @@ export function useConfig(options?: UseConfigOptions): UseConfigResult {
         await queuePush(user.id);
         return;
       }
-      if (!validateConfig(remote.config)) {
+      const remoteConfig = parseConfig(remote.config);
+      if (!remoteConfig) {
         throw new Error('The synced configuration is invalid.');
       }
 
@@ -340,16 +342,16 @@ export function useConfig(options?: UseConfigOptions): UseConfigResult {
       if (activation !== activationRef.current) return;
 
       if (
-        configsEqual(guest, remote.config)
+        configsEqual(guest, remoteConfig)
         || (defaultConfig !== null && configsEqual(guest, defaultConfig))
       ) {
         accountReadyRef.current = true;
         saveAccountCache(user.id, {
-          config: remote.config,
+          config: remoteConfig,
           remoteUpdatedAt: remote.updatedAt,
           dirty: false,
         });
-        applyConfig(remote.config);
+        applyConfig(remoteConfig);
         setLastSyncedAt(remote.updatedAt);
         setSyncStatus('synced');
       } else {
@@ -357,7 +359,7 @@ export function useConfig(options?: UseConfigOptions): UseConfigResult {
         applyConfig(guest);
         setInitialSyncConflict({
           browserConfig: guest,
-          syncedConfig: remote.config,
+          syncedConfig: remoteConfig,
           syncedUpdatedAt: remote.updatedAt,
         });
       }

--- a/src/screens/ConfigEditorScreen/ConfigEditorScreen.test.tsx
+++ b/src/screens/ConfigEditorScreen/ConfigEditorScreen.test.tsx
@@ -89,6 +89,26 @@ describe('ConfigEditorScreen', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  it('migrates removed fields out of an imported config', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<ConfigEditor {...defaultProps} onSave={onSave} />);
+
+    await user.click(screen.getByRole('button', { name: 'Import' }));
+
+    const modal = screen.getByText('Import Config').closest('.config-editor-modal')!;
+    const textarea = within(modal as HTMLElement).getByPlaceholderText('Paste exported base64 string here...');
+
+    const legacyConfig = {
+      ...mockConfig,
+      modules: mockConfig.modules.map((module) => ({ ...module, columns: 3 })),
+    };
+    await user.type(textarea, btoa(JSON.stringify(legacyConfig)));
+    await user.click(within(modal as HTMLElement).getByRole('button', { name: 'Apply' }));
+
+    expect(onSave).toHaveBeenCalledWith(mockConfig);
+  });
+
   it('shows import error on invalid base64 input', async () => {
     const user = userEvent.setup();
     render(<ConfigEditor {...defaultProps} />);

--- a/src/screens/ConfigEditorScreen/ConfigEditorScreen.tsx
+++ b/src/screens/ConfigEditorScreen/ConfigEditorScreen.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import type { AppConfig, BackgroundConfig } from '../../types/config.ts';
-import { validateConfig } from '../../utils/configValidation.ts';
+import { parseConfig } from '../../utils/configValidation.ts';
 import { GeneralTab } from './components/GeneralTab.tsx';
 import { LinksTab } from './components/LinksTab.tsx';
 import { SubcommandsTab } from './components/SubcommandsTab.tsx';
@@ -130,12 +130,13 @@ export function ConfigEditor({
       return;
     }
 
-    if (!validateConfig(parsed)) {
+    const imported = parseConfig(parsed);
+    if (!imported) {
       setImportError('JSON does not match the expected config format.');
       return;
     }
 
-    onSave(parsed);
+    onSave(imported);
     onClose();
   };
 

--- a/src/screens/ConfigEditorScreen/components/GeneralTab.test.tsx
+++ b/src/screens/ConfigEditorScreen/components/GeneralTab.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { GeneralTab } from './GeneralTab.tsx';
-import { mockConfig, mockBackgroundWithImage } from '../../../test/fixtures.ts';
+import { mockConfig, mockConfigNoSearch, mockBackgroundWithImage } from '../../../test/fixtures.ts';
 import type { AppConfig, BackgroundConfig } from '../../../types/config.ts';
 
 describe('GeneralTab', () => {
@@ -93,6 +93,65 @@ describe('GeneralTab', () => {
 
     const savedConfig = onSave.mock.calls[0][0] as AppConfig;
     expect(savedConfig.search?.enabled).toBe(true);
+  });
+
+  it('reflects the configured search enabled state in the toggle', () => {
+    const { unmount } = render(<GeneralTab {...defaultProps} />);
+    expect(screen.getByLabelText('Enable Search Bar')).toBeChecked();
+    unmount();
+
+    render(<GeneralTab {...defaultProps} config={mockConfigNoSearch} />);
+    expect(screen.getByLabelText('Enable Search Bar')).not.toBeChecked();
+  });
+
+  it('saves search as disabled when the toggle is turned off', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<GeneralTab {...defaultProps} onSave={onSave} />);
+
+    await user.click(screen.getByLabelText('Enable Search Bar'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const savedConfig = onSave.mock.calls[0][0] as AppConfig;
+    expect(savedConfig.search?.enabled).toBe(false);
+  });
+
+  it('saves search as enabled when the toggle is turned on', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<GeneralTab {...defaultProps} config={mockConfigNoSearch} onSave={onSave} />);
+
+    await user.click(screen.getByLabelText('Enable Search Bar'));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const savedConfig = onSave.mock.calls[0][0] as AppConfig;
+    expect(savedConfig.search?.enabled).toBe(true);
+  });
+
+  it('keeps the configured placeholder when search is disabled', async () => {
+    const user = userEvent.setup();
+    const onSave = vi.fn();
+    render(<GeneralTab {...defaultProps} onSave={onSave} />);
+
+    await user.click(screen.getByLabelText('Enable Search Bar'));
+    expect(screen.queryByPlaceholderText('Filter links...')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    const savedConfig = onSave.mock.calls[0][0] as AppConfig;
+    expect(savedConfig.search).toEqual({ enabled: false, placeholder: 'Filter links...' });
+  });
+
+  it('pushes the toggled search state to the shared draft', async () => {
+    const user = userEvent.setup();
+    const onConfigChange = vi.fn();
+    render(<GeneralTab {...defaultProps} onConfigChange={onConfigChange} />);
+
+    await user.click(screen.getByLabelText('Enable Search Bar'));
+
+    const draft = onConfigChange.mock.calls.at(-1)?.[0] as AppConfig;
+    expect(draft.search?.enabled).toBe(false);
+    expect(draft.search?.placeholder).toBe('Filter links...');
   });
 
   it('renders background color input', () => {

--- a/src/screens/ConfigEditorScreen/components/GeneralTab.tsx
+++ b/src/screens/ConfigEditorScreen/components/GeneralTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import type { AppConfig, BackgroundConfig, ForegroundSetting, GradientDirection } from '../../../types/config.ts';
+import type { AppConfig, BackgroundConfig, ForegroundSetting, GradientDirection, SearchConfig } from '../../../types/config.ts';
 
 const DIRECTION_ARROWS: { value: GradientDirection; arrow: string }[] = [
   { value: 'up', arrow: '↑' },
@@ -31,6 +31,7 @@ export function GeneralTab({ config, onSave, onClose, onPreview, onConfigChange 
   const [gradientColor2, setGradientColor2] = useState(config.background?.gradient?.color2 ?? '#000000');
   const [gradientDirection, setGradientDirection] = useState<GradientDirection>(config.background?.gradient?.direction ?? 'down');
   const [foreground, setForeground] = useState<ForegroundSetting>(config.background?.foreground ?? 'auto');
+  const [searchEnabled, setSearchEnabled] = useState(config.search?.enabled ?? false);
   const [placeholder, setPlaceholder] = useState(config.search?.placeholder ?? '');
 
   const hasImage = appliedImageUrl.trim() !== '';
@@ -48,19 +49,22 @@ export function GeneralTab({ config, onSave, onClose, onPreview, onConfigChange 
     },
   });
 
+  // The placeholder is kept even while search is disabled so re-enabling restores it
+  const currentSearch = (): SearchConfig => ({
+    ...config.search,
+    enabled: searchEnabled,
+    placeholder: placeholder || undefined,
+  });
+
   // Push general-tab changes to the shared draft so they persist across tab switches
   useEffect(() => {
     const updated: AppConfig = {
       ...config,
       background: currentBackground(),
-      search: {
-        ...config.search,
-        enabled: config.search?.enabled ?? false,
-        placeholder: placeholder || undefined,
-      },
+      search: currentSearch(),
     };
     onConfigChange(updated);
-  }, [appliedImageUrl, opacity, color, foreground, gradientEnabled, gradientColor2, gradientDirection, placeholder]);// eslint-disable-line react-hooks/exhaustive-deps
+  }, [appliedImageUrl, opacity, color, foreground, gradientEnabled, gradientColor2, gradientDirection, searchEnabled, placeholder]);// eslint-disable-line react-hooks/exhaustive-deps
 
   const buildGradient = (updates: { enabled?: boolean; color2?: string; direction?: GradientDirection } = {}) => ({
     enabled: updates.enabled ?? gradientEnabled,
@@ -100,11 +104,7 @@ export function GeneralTab({ config, onSave, onClose, onPreview, onConfigChange 
     onSave({
       ...config,
       background: currentBackground(),
-      search: {
-        ...config.search,
-        enabled: config.search?.enabled ?? false,
-        placeholder: placeholder || undefined,
-      },
+      search: currentSearch(),
     });
   };
 
@@ -240,15 +240,28 @@ export function GeneralTab({ config, onSave, onClose, onPreview, onConfigChange 
         <h2 className="config-editor-section-title">Search</h2>
 
         <div className="config-editor-field">
-          <span className="config-editor-label">Placeholder</span>
-          <input
-            type="text"
-            className="config-editor-input"
-            value={placeholder}
-            onChange={(e) => setPlaceholder(e.target.value)}
-            placeholder="Filter links..."
-          />
+          <label className="config-editor-toggle">
+            <input
+              type="checkbox"
+              checked={searchEnabled}
+              onChange={(e) => setSearchEnabled(e.target.checked)}
+            />
+            <span className="config-editor-toggle-label">Enable Search Bar</span>
+          </label>
         </div>
+
+        {searchEnabled && (
+          <div className="config-editor-field">
+            <span className="config-editor-label">Placeholder</span>
+            <input
+              type="text"
+              className="config-editor-input"
+              value={placeholder}
+              onChange={(e) => setPlaceholder(e.target.value)}
+              placeholder="Filter links..."
+            />
+          </div>
+        )}
       </div>
 
       <div className="config-editor-actions">

--- a/src/utils/configValidation.test.ts
+++ b/src/utils/configValidation.test.ts
@@ -1,5 +1,6 @@
-import { configsEqual, validateConfig } from './configValidation.ts';
-import { mockConfig } from '../test/fixtures.ts';
+import { configsEqual, migrateConfig, parseConfig, validateConfig } from './configValidation.ts';
+import { mockConfig, mockLink } from '../test/fixtures.ts';
+import type { AppConfig } from '../types/config.ts';
 import seedConfig from '../../public/config.json';
 
 describe('config validation', () => {
@@ -77,5 +78,49 @@ describe('config validation', () => {
       modules: [],
       subcommands: [{ name: 'GitHub', trigger: 'gh', items: [], freeform }],
     })).toBe(false);
+  });
+});
+
+describe('config migration', () => {
+  const legacyConfig = {
+    version: 1,
+    modules: [
+      { type: 'links', title: 'Favorites', columns: 3, links: [mockLink] },
+      { type: 'links', title: 'Tools', columns: 2, links: [] },
+    ],
+  };
+
+  it('still accepts configs that contain the removed columns field', () => {
+    expect(validateConfig(legacyConfig)).toBe(true);
+  });
+
+  it('drops the removed columns field from every module', () => {
+    const migrated = migrateConfig(legacyConfig as unknown as AppConfig);
+
+    for (const module of migrated.modules) {
+      expect(module).not.toHaveProperty('columns');
+    }
+    expect(migrated.modules.map((module) => module.title)).toEqual(['Favorites', 'Tools']);
+    expect(migrated.modules[0].links).toEqual([mockLink]);
+  });
+
+  it('returns the same reference when there is nothing to migrate', () => {
+    expect(migrateConfig(mockConfig)).toBe(mockConfig);
+  });
+
+  it('does not mutate the config it migrates', () => {
+    const original = structuredClone(legacyConfig);
+    migrateConfig(legacyConfig as unknown as AppConfig);
+    expect(legacyConfig).toEqual(original);
+  });
+
+  it('parses and migrates in one step, rejecting invalid values', () => {
+    const parsed = parseConfig(legacyConfig);
+    expect(parsed?.modules[0]).not.toHaveProperty('columns');
+    expect(parseConfig({ version: '1', modules: [] })).toBeNull();
+  });
+
+  it('keeps the bundled seed config free of removed fields', () => {
+    expect(migrateConfig(seedConfig as AppConfig)).toBe(seedConfig);
   });
 });

--- a/src/utils/configValidation.ts
+++ b/src/utils/configValidation.ts
@@ -1,4 +1,4 @@
-import type { AppConfig } from '../types/config.ts';
+import type { AppConfig, ModuleConfig } from '../types/config.ts';
 import {
   isHttpUrl,
   isValidFreeform,
@@ -110,6 +110,35 @@ export function validateConfig(value: unknown): value is AppConfig {
   }
 
   return true;
+}
+
+/** Module fields that were once documented but are no longer part of the schema. */
+const LEGACY_MODULE_KEYS = ['columns'] as const;
+
+/**
+ * Drops fields that are no longer supported so older configs converge on the
+ * current schema. Returns the original config when nothing changed, keeping
+ * reference equality for untouched configs.
+ */
+export function migrateConfig(config: AppConfig): AppConfig {
+  let changed = false;
+
+  const modules = config.modules.map((module) => {
+    const record = module as unknown as Record<string, unknown>;
+    if (!LEGACY_MODULE_KEYS.some((key) => key in record)) return module;
+
+    changed = true;
+    const next = { ...record };
+    for (const key of LEGACY_MODULE_KEYS) delete next[key];
+    return next as unknown as ModuleConfig;
+  });
+
+  return changed ? { ...config, modules } : config;
+}
+
+/** Validates and migrates an unknown value, returning `null` when invalid. */
+export function parseConfig(value: unknown): AppConfig | null {
+  return validateConfig(value) ? migrateConfig(value) : null;
 }
 
 function valuesEqual(left: unknown, right: unknown): boolean {


### PR DESCRIPTION
Closes #51.

The public config contract and the app disagreed in a few places. This aligns them.

## `modules[].columns` — removed and migrated

`columns` was documented and present in `public/config.json`, but was never in `ModuleConfig` and never read by `LinkModule`. Sections already lay out in a responsive auto-fill grid with links wrapping to fill the width, so a fixed per-module column count has no place in the current layout — it's removed rather than implemented.

- New `migrateConfig` in `src/utils/configValidation.ts` strips the field, returning the same reference when nothing changed.
- New `parseConfig` (validate + migrate) replaces `validateConfig` at every entry point: localStorage guest/active configs, the account cache, the fetched seed, both remote-sync reads, and base64 import. Existing configs converge on the current schema the next time they load, with no layout change.
- `validateConfig` still accepts configs containing `columns`, so nothing already saved is rejected.

## Search toggle in Settings

`search.enabled` was only reachable by editing or importing raw config. General → Search now has an **Enable Search Bar** toggle. The placeholder is preserved while search is off (and its input hidden), so re-enabling restores it.

## Documentation

- Removed `columns` from the tables and example, with a note on the migration.
- Documented `modules[].hidden` and `modules[].links[].hidden`, including that hidden entries stay searchable.
- Documented `background.foreground`, which was supported but missing.
- Replaced the stale "case-insensitive substring match on label" description with the actual scored, multi-field behavior: weighted label/section/URL scoring, alphanumeric-normalized comparison, exact > prefix > substring ranking, all-words-must-match for multi-word queries, top 5 results, and the keyboard bindings.

## Tests

Added coverage for the migration (validation, module stripping, no mutation, reference identity, seed config), migration through `useConfig` load/fetch and through import, and search toggling in both directions plus placeholder preservation.

`npm run lint && npm run test && npm run build` all pass (221 tests).

Custom link icon editing remains tracked by #42 and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)